### PR TITLE
fix: Correct Hytale commands, add persistence, and server memory stats

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -132,9 +132,12 @@ This document lists all available commands for the Hytale server. Commands can b
 
 | Command | Description | Usage |
 |---------|-------------|-------|
-| `/teleport playertoplayer` | Teleport player to player | `/teleport playertoplayer <source> <target>` |
-| `/teleport tocoordinates` | Teleport to coordinates | `/teleport tocoordinates <player> <x> <y> <z>` |
-| `/teleport toworld` | Teleport to world spawn | `/teleport toworld <player> <world>` |
+| `/tp` | Teleport player to player | `/tp <player> <target>` |
+| `/tp` | Teleport to coordinates | `/tp <player> <x> <y> <z>` |
+| `/tp` | Teleport self to player | `/tp <target>` |
+| `/tp` | Teleport self to coords | `/tp <x> <y> <z>` |
+| `/tp` | Teleport to world | `/tp <player> <x> <y> <z> --world <name>` |
+| `/top` | Teleport to top | `/top` |
 | `/spawn` | Teleport to spawn | `/spawn [player]` |
 | `/home` | Teleport to home | `/home [player]` |
 | `/sethome` | Set home location | `/sethome [player]` |
@@ -237,11 +240,13 @@ Example permissions:
 /kick <player>                    - Kick player
 /ban <player>                     - Ban player
 /op add <player>                  - Give OP
-/teleport playertoplayer <p1> <p2> - Teleport player to player
+/tp <player> <target>             - Teleport player to player
+/tp <player> <x> <y> <z>          - Teleport to coordinates
 /gamemode creative <player>       - Set creative mode
 /give <player> <item> <amount>    - Give items
 /time set day                     - Set daytime
 /weather clear                    - Clear weather
+/server stats memory              - Show memory stats
 /save                            - Save worlds
 /stop                            - Stop server
 ```

--- a/manager/backend/src/types/index.ts
+++ b/manager/backend/src/types/index.ts
@@ -48,6 +48,7 @@ export interface ActionResponse {
   success: boolean;
   message?: string;
   error?: string;
+  output?: string;
 }
 
 // Console Types

--- a/manager/frontend/src/api/server.ts
+++ b/manager/frontend/src/api/server.ts
@@ -26,6 +26,26 @@ export interface ActionResponse {
   error?: string
 }
 
+export interface ServerMemoryStats {
+  available: boolean
+  physical?: {
+    total: number | null
+    free: number | null
+  }
+  swap?: {
+    total: number | null
+    free: number | null
+  }
+  heap?: {
+    init: number | null
+    used: number | null
+    committed: number | null
+    max: number | null
+  }
+  raw?: string
+  error?: string
+}
+
 export interface ConfigFile {
   name: string
   size: number
@@ -49,6 +69,11 @@ export const serverApi = {
 
   async getStats(): Promise<ServerStats> {
     const response = await api.get<ServerStats>('/server/stats')
+    return response.data
+  },
+
+  async getMemoryStats(): Promise<ServerMemoryStats> {
+    const response = await api.get<ServerMemoryStats>('/server/memory')
     return response.data
   },
 

--- a/manager/frontend/src/i18n/de.json
+++ b/manager/frontend/src/i18n/de.json
@@ -242,7 +242,16 @@
     "containerName": "Container Name",
     "containerId": "Container ID",
     "memoryLimit": "Speicher Limit",
-    "dataPoints": "Datenpunkte"
+    "dataPoints": "Datenpunkte",
+    "serverMemory": "Server Speicher (JVM)",
+    "heapMemory": "JVM Heap Speicher",
+    "physicalMemory": "Physischer Speicher",
+    "swapMemory": "Swap Speicher",
+    "used": "Benutzt",
+    "free": "Frei",
+    "total": "Gesamt",
+    "init": "Init",
+    "committed": "Reserviert"
   },
   "settings": {
     "title": "Einstellungen",

--- a/manager/frontend/src/i18n/en.json
+++ b/manager/frontend/src/i18n/en.json
@@ -242,7 +242,16 @@
     "containerName": "Container Name",
     "containerId": "Container ID",
     "memoryLimit": "Memory Limit",
-    "dataPoints": "Data Points"
+    "dataPoints": "Data Points",
+    "serverMemory": "Server Memory (JVM)",
+    "heapMemory": "JVM Heap Memory",
+    "physicalMemory": "Physical Memory",
+    "swapMemory": "Swap Memory",
+    "used": "Used",
+    "free": "Free",
+    "total": "Total",
+    "init": "Init",
+    "committed": "Committed"
   },
   "settings": {
     "title": "Settings",


### PR DESCRIPTION
Commands:
- Fix teleport to use correct /tp syntax instead of /teleport playertoplayer
- Update docs/COMMANDS.md with verified Hytale command syntax

Whitelist & Bans:
- Add file persistence (whitelist.json, bans.json) when using player API
- Kick player before banning to remove them immediately
- Remove banned players from whitelist automatically
- Add activity logging for all player management actions

Performance:
- Add /server stats memory endpoint to fetch JVM heap stats
- Display physical memory, swap memory, and JVM heap usage
- Add progress bars for memory visualization
- Add i18n translations for new memory stats labels

Types:
- Add output property to ActionResponse for command results