### PR TITLE
feat: add operator role with limited permissions

### DIFF
--- a/manager/backend/src/services/users.ts
+++ b/manager/backend/src/services/users.ts
@@ -7,7 +7,7 @@ import { config } from '../config.js';
 export interface User {
   username: string;
   passwordHash: string;
-  role: 'admin' | 'moderator' | 'viewer';
+  role: 'admin' | 'moderator' | 'operator' | 'viewer';
   createdAt: string;
   lastLogin?: string;
 }

--- a/manager/frontend/src/api/users.ts
+++ b/manager/frontend/src/api/users.ts
@@ -2,7 +2,7 @@ import api from './client'
 
 export interface User {
   username: string
-  role: 'admin' | 'moderator' | 'viewer'
+  role: 'admin' | 'moderator' | 'operator' | 'viewer'
   createdAt: string
   lastLogin?: string
 }

--- a/manager/frontend/src/components/layout/Sidebar.vue
+++ b/manager/frontend/src/components/layout/Sidebar.vue
@@ -8,35 +8,51 @@ const { t } = useI18n()
 const route = useRoute()
 const authStore = useAuthStore()
 
+type Permission = 'all' | 'console' | 'performance' | 'managePlayers' | 'manageBackups' | 'manageConfig' | 'admin'
+
 interface NavItem {
   name: string
   path: string
   icon: string
   label: string
   group?: string
-  adminOnly?: boolean
+  permission?: Permission
+}
+
+// Check if user has permission for a nav item
+function hasPermission(permission?: Permission): boolean {
+  if (!permission || permission === 'all') return true
+  switch (permission) {
+    case 'console': return authStore.canViewConsole
+    case 'performance': return authStore.canViewPerformance
+    case 'managePlayers': return authStore.canManagePlayers
+    case 'manageBackups': return authStore.canManageBackups
+    case 'manageConfig': return authStore.canManageConfig
+    case 'admin': return authStore.isAdmin
+    default: return true
+  }
 }
 
 const navItems = computed<NavItem[]>(() => [
-  { name: 'dashboard', path: '/', icon: 'dashboard', label: t('nav.dashboard'), group: 'main' },
-  { name: 'console', path: '/console', icon: 'console', label: t('nav.console'), group: 'main' },
-  { name: 'performance', path: '/performance', icon: 'performance', label: t('nav.performance'), group: 'main' },
-  { name: 'players', path: '/players', icon: 'players', label: t('nav.players'), group: 'management' },
-  { name: 'whitelist', path: '/whitelist', icon: 'whitelist', label: t('nav.whitelist'), group: 'management' },
-  { name: 'permissions', path: '/permissions', icon: 'permissions', label: t('nav.permissions'), group: 'management' },
-  { name: 'worlds', path: '/worlds', icon: 'worlds', label: t('nav.worlds'), group: 'management' },
-  { name: 'mods', path: '/mods', icon: 'mods', label: t('nav.mods'), group: 'management' },
-  { name: 'backups', path: '/backups', icon: 'backup', label: t('nav.backups'), group: 'data' },
-  { name: 'configuration', path: '/configuration', icon: 'configuration', label: t('nav.configuration'), group: 'data' },
-  { name: 'settings', path: '/settings', icon: 'settings', label: t('nav.settings'), group: 'data' },
-  { name: 'users', path: '/users', icon: 'users', label: t('nav.users'), group: 'admin', adminOnly: true },
-  { name: 'activity', path: '/activity', icon: 'activity', label: t('nav.activityLog'), group: 'admin', adminOnly: true },
+  { name: 'dashboard', path: '/', icon: 'dashboard', label: t('nav.dashboard'), group: 'main', permission: 'all' },
+  { name: 'console', path: '/console', icon: 'console', label: t('nav.console'), group: 'main', permission: 'console' },
+  { name: 'performance', path: '/performance', icon: 'performance', label: t('nav.performance'), group: 'main', permission: 'performance' },
+  { name: 'players', path: '/players', icon: 'players', label: t('nav.players'), group: 'management', permission: 'managePlayers' },
+  { name: 'whitelist', path: '/whitelist', icon: 'whitelist', label: t('nav.whitelist'), group: 'management', permission: 'managePlayers' },
+  { name: 'permissions', path: '/permissions', icon: 'permissions', label: t('nav.permissions'), group: 'management', permission: 'managePlayers' },
+  { name: 'worlds', path: '/worlds', icon: 'worlds', label: t('nav.worlds'), group: 'management', permission: 'managePlayers' },
+  { name: 'mods', path: '/mods', icon: 'mods', label: t('nav.mods'), group: 'management', permission: 'managePlayers' },
+  { name: 'backups', path: '/backups', icon: 'backup', label: t('nav.backups'), group: 'data', permission: 'manageBackups' },
+  { name: 'configuration', path: '/configuration', icon: 'configuration', label: t('nav.configuration'), group: 'data', permission: 'manageConfig' },
+  { name: 'settings', path: '/settings', icon: 'settings', label: t('nav.settings'), group: 'data', permission: 'all' },
+  { name: 'users', path: '/users', icon: 'users', label: t('nav.users'), group: 'admin', permission: 'admin' },
+  { name: 'activity', path: '/activity', icon: 'activity', label: t('nav.activityLog'), group: 'admin', permission: 'admin' },
 ])
 
-const mainItems = computed(() => navItems.value.filter(i => i.group === 'main'))
-const managementItems = computed(() => navItems.value.filter(i => i.group === 'management'))
-const dataItems = computed(() => navItems.value.filter(i => i.group === 'data'))
-const adminItems = computed(() => navItems.value.filter(i => i.group === 'admin' && (!i.adminOnly || authStore.isAdmin)))
+const mainItems = computed(() => navItems.value.filter(i => i.group === 'main' && hasPermission(i.permission)))
+const managementItems = computed(() => navItems.value.filter(i => i.group === 'management' && hasPermission(i.permission)))
+const dataItems = computed(() => navItems.value.filter(i => i.group === 'data' && hasPermission(i.permission)))
+const adminItems = computed(() => navItems.value.filter(i => i.group === 'admin' && hasPermission(i.permission)))
 
 function isActive(path: string): boolean {
   return route.path === path

--- a/manager/frontend/src/i18n/de.json
+++ b/manager/frontend/src/i18n/de.json
@@ -294,11 +294,13 @@
     "roles": {
       "admin": "Administrator",
       "moderator": "Moderator",
+      "operator": "Operator",
       "viewer": "Betrachter"
     },
     "rolesInfo": "Benutzerrollen",
     "adminDesc": "Vollzugriff auf alle Funktionen",
     "moderatorDesc": "Kann Server verwalten, aber keine Benutzer",
+    "operatorDesc": "Kann Dashboard, Konsole, Performance sehen und Server neustarten",
     "viewerDesc": "Nur Lesezugriff",
     "created": "Erstellt",
     "lastLogin": "Letzter Login",

--- a/manager/frontend/src/i18n/en.json
+++ b/manager/frontend/src/i18n/en.json
@@ -294,11 +294,13 @@
     "roles": {
       "admin": "Administrator",
       "moderator": "Moderator",
+      "operator": "Operator",
       "viewer": "Viewer"
     },
     "rolesInfo": "User Roles",
     "adminDesc": "Full access to all features",
     "moderatorDesc": "Can manage server but not users",
+    "operatorDesc": "Can view dashboard, console, performance and restart server",
     "viewerDesc": "Read-only access",
     "created": "Created",
     "lastLogin": "Last Login",

--- a/manager/frontend/src/stores/auth.ts
+++ b/manager/frontend/src/stores/auth.ts
@@ -22,7 +22,7 @@ const removeStorageItem = (key: string): void => {
   }
 }
 
-export type UserRole = 'admin' | 'moderator' | 'viewer'
+export type UserRole = 'admin' | 'moderator' | 'operator' | 'viewer'
 
 export const useAuthStore = defineStore('auth', () => {
   // State
@@ -35,6 +35,16 @@ export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = computed(() => !!accessToken.value)
   const isAdmin = computed(() => role.value === 'admin')
   const canManageServer = computed(() => role.value === 'admin' || role.value === 'moderator')
+
+  // Operator permissions: can view dashboard, console, performance + restart server
+  const canRestartServer = computed(() => ['admin', 'moderator', 'operator'].includes(role.value || ''))
+  const canViewConsole = computed(() => ['admin', 'moderator', 'operator'].includes(role.value || ''))
+  const canViewPerformance = computed(() => ['admin', 'moderator', 'operator'].includes(role.value || ''))
+
+  // Only admin/moderator can manage players, backups, mods, etc.
+  const canManagePlayers = computed(() => ['admin', 'moderator'].includes(role.value || ''))
+  const canManageBackups = computed(() => ['admin', 'moderator'].includes(role.value || ''))
+  const canManageConfig = computed(() => ['admin', 'moderator'].includes(role.value || ''))
 
   // Actions
   function setTokens(access: string, refresh: string) {
@@ -90,6 +100,12 @@ export const useAuthStore = defineStore('auth', () => {
     isAuthenticated,
     isAdmin,
     canManageServer,
+    canRestartServer,
+    canViewConsole,
+    canViewPerformance,
+    canManagePlayers,
+    canManageBackups,
+    canManageConfig,
     // Actions
     setTokens,
     setUser,

--- a/manager/frontend/src/views/Users.vue
+++ b/manager/frontend/src/views/Users.vue
@@ -108,6 +108,8 @@ function getRoleBadgeClass(role: User['role']): string {
       return 'bg-status-error/20 text-status-error'
     case 'moderator':
       return 'bg-hytale-orange/20 text-hytale-orange'
+    case 'operator':
+      return 'bg-blue-500/20 text-blue-400'
     default:
       return 'bg-gray-500/20 text-gray-400'
   }
@@ -164,6 +166,7 @@ onMounted(loadUsers)
           <div class="text-sm text-gray-400 mt-2 space-y-1">
             <p><span class="text-status-error font-medium">Admin:</span> {{ t('users.adminDesc') }}</p>
             <p><span class="text-hytale-orange font-medium">Moderator:</span> {{ t('users.moderatorDesc') }}</p>
+            <p><span class="text-blue-400 font-medium">Operator:</span> {{ t('users.operatorDesc') }}</p>
             <p><span class="text-gray-400 font-medium">Viewer:</span> {{ t('users.viewerDesc') }}</p>
           </div>
         </div>
@@ -275,6 +278,7 @@ onMounted(loadUsers)
               class="w-full px-4 py-2 bg-dark-100 border border-dark-50 rounded-lg text-white focus:outline-none focus:border-hytale-orange"
             >
               <option value="viewer">{{ t('users.roles.viewer') }}</option>
+              <option value="operator">{{ t('users.roles.operator') }}</option>
               <option value="moderator">{{ t('users.roles.moderator') }}</option>
               <option value="admin">{{ t('users.roles.admin') }}</option>
             </select>
@@ -327,6 +331,7 @@ onMounted(loadUsers)
               class="w-full px-4 py-2 bg-dark-100 border border-dark-50 rounded-lg text-white focus:outline-none focus:border-hytale-orange"
             >
               <option value="viewer">{{ t('users.roles.viewer') }}</option>
+              <option value="operator">{{ t('users.roles.operator') }}</option>
               <option value="moderator">{{ t('users.roles.moderator') }}</option>
               <option value="admin">{{ t('users.roles.admin') }}</option>
             </select>


### PR DESCRIPTION
New 'operator' role that can:
- View Dashboard, Console, Performance
- Restart/Stop/Start server
- Cannot access: Players, Whitelist, Permissions, Worlds, Mods, Backups, Configuration, Users, Activity Log

Changes:
- Added operator to role types in backend and frontend
- Added permission checks in auth store (canViewConsole, canViewPerformance, canManagePlayers, canManageBackups, etc.)
- Updated Sidebar to show/hide items based on permissions
- Added operator option to user management UI
- Added i18n translations (EN/DE) for operator role