### PR TITLE
chore: remove beta suffix from all references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # PORTAINER: Diese Werte direkt in "Environment Variables" setzen
 #            (NICHT als .env Datei hochladen!)
 #
-# Host-Pfade: /opt/hytale-beta/
+# Host-Pfade: /opt/hytale/
 # ============================================================
 
 # ====================

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Dateien findest du in: `%appdata%\Hytale\install\release\package\game\latest\`
 **Option C: Manuell kopieren**
 
 ```bash
-docker cp Server/HytaleServer.jar hytale-beta:/opt/hytale/server/
-docker cp Assets.zip hytale-beta:/opt/hytale/server/
-docker restart hytale-beta
+docker cp Server/HytaleServer.jar hytale:/opt/hytale/server/
+docker cp Assets.zip hytale:/opt/hytale/server/
+docker restart hytale
 ```
 
 #### 3. Server authentifizieren
@@ -111,7 +111,7 @@ docker restart hytale-beta
 Nach dem ersten Start muss der Hytale-Server authentifiziert werden:
 
 ```bash
-docker attach hytale-beta
+docker attach hytale
 /auth login device
 ```
 
@@ -182,25 +182,25 @@ Router Port-Forwarding:
 
 ```bash
 # Logs anzeigen
-docker logs -f hytale-beta
+docker logs -f hytale
 
 # Console öffnen (verlassen: Ctrl+P, Ctrl+Q)
-docker attach hytale-beta
+docker attach hytale
 
 # Manuelles Backup
-docker exec hytale-beta /opt/hytale/backup.sh
+docker exec hytale /opt/hytale/backup.sh
 
 # Neustart
-docker restart hytale-beta
+docker restart hytale
 ```
 
 ### Updates
 
 Mit Hytale Downloader:
 ```bash
-docker stop hytale-beta
+docker stop hytale
 docker volume rm hytale-server
-docker start hytale-beta
+docker start hytale
 ```
 
 ---
@@ -260,9 +260,9 @@ Files can be found in: `%appdata%\Hytale\install\release\package\game\latest\`
 **Option C: Manual Copy**
 
 ```bash
-docker cp Server/HytaleServer.jar hytale-beta:/opt/hytale/server/
-docker cp Assets.zip hytale-beta:/opt/hytale/server/
-docker restart hytale-beta
+docker cp Server/HytaleServer.jar hytale:/opt/hytale/server/
+docker cp Assets.zip hytale:/opt/hytale/server/
+docker restart hytale
 ```
 
 #### 3. Server Authentication
@@ -270,7 +270,7 @@ docker restart hytale-beta
 After first start, the Hytale server needs to be authenticated:
 
 ```bash
-docker attach hytale-beta
+docker attach hytale
 /auth login device
 ```
 
@@ -341,25 +341,25 @@ Router port forwarding:
 
 ```bash
 # View logs
-docker logs -f hytale-beta
+docker logs -f hytale
 
 # Open console (exit: Ctrl+P, Ctrl+Q)
-docker attach hytale-beta
+docker attach hytale
 
 # Manual backup
-docker exec hytale-beta /opt/hytale/backup.sh
+docker exec hytale /opt/hytale/backup.sh
 
 # Restart
-docker restart hytale-beta
+docker restart hytale
 ```
 
 ### Updates
 
 With Hytale Downloader:
 ```bash
-docker stop hytale-beta
+docker stop hytale
 docker volume rm hytale-server
-docker start hytale-beta
+docker start hytale
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Hytale Dedicated Server - Docker Compose
 # ============================================================
 #
-# HOST PFADE: /opt/hytale-beta/
+# HOST PFADE: /opt/hytale/
 # CONTAINER PFADE: /opt/hytale/
 #
 # PORTAINER SETUP:
@@ -23,10 +23,10 @@
 # ============================================================
 
 services:
-  hytale-beta:
+  hytale:
     build: .
-    container_name: hytale-beta
-    hostname: hytale-beta
+    container_name: hytale
+    hostname: hytale
     restart: on-failure:3
     
     environment:
@@ -61,15 +61,15 @@ services:
     ports:
       - "${SERVER_PORT:-5520}:${SERVER_PORT:-5520}/udp"
     
-    # Volumes - Bind Mounts zu /opt/hytale-beta/
+    # Volumes - Bind Mounts zu /opt/hytale/
     volumes:
-      - /opt/hytale-beta/server:/opt/hytale/server
-      - /opt/hytale-beta/data:/opt/hytale/data
-      - /opt/hytale-beta/backups:/opt/hytale/backups
-      - /opt/hytale-beta/plugins:/opt/hytale/plugins
-      - /opt/hytale-beta/mods:/opt/hytale/mods
-      - /opt/hytale-beta/downloader:/opt/hytale/downloader
-      - /opt/hytale-beta/auth:/opt/hytale/auth
+      - /opt/hytale/server:/opt/hytale/server
+      - /opt/hytale/data:/opt/hytale/data
+      - /opt/hytale/backups:/opt/hytale/backups
+      - /opt/hytale/plugins:/opt/hytale/plugins
+      - /opt/hytale/mods:/opt/hytale/mods
+      - /opt/hytale/downloader:/opt/hytale/downloader
+      - /opt/hytale/auth:/opt/hytale/auth
 
     # Console
     stdin_open: true
@@ -84,15 +84,15 @@ services:
 
     # Network for manager communication
     networks:
-      - hytale-beta-net
+      - hytale-net
 
   # ============================================================
   # Hytale Server Manager - Web UI
   # ============================================================
-  hytale-beta-manager:
+  hytale-manager:
     build: ./manager
-    container_name: hytale-beta-manager
-    hostname: hytale-beta-manager
+    container_name: hytale-manager
+    hostname: hytale-manager
     restart: unless-stopped
 
     environment:
@@ -102,7 +102,7 @@ services:
       - JWT_SECRET=${JWT_SECRET:-please-change-this-secret-key}
 
       # Target container
-      - GAME_CONTAINER_NAME=hytale-beta
+      - GAME_CONTAINER_NAME=hytale
 
       # Paths (inside container)
       - SERVER_PATH=/opt/hytale/server
@@ -119,22 +119,22 @@ services:
       # Docker socket for container management
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
-      # Shared volumes with game server (host: /opt/hytale-beta/, container: /opt/hytale/)
+      # Shared volumes with game server (host: /opt/hytale/, container: /opt/hytale/)
       # Server configs need write access for the config editor
-      - /opt/hytale-beta/server:/opt/hytale/server
-      - /opt/hytale-beta/backups:/opt/hytale/backups
-      - /opt/hytale-beta/data:/opt/hytale/data
-      - /opt/hytale-beta/mods:/opt/hytale/mods
-      - /opt/hytale-beta/plugins:/opt/hytale/plugins
+      - /opt/hytale/server:/opt/hytale/server
+      - /opt/hytale/backups:/opt/hytale/backups
+      - /opt/hytale/data:/opt/hytale/data
+      - /opt/hytale/mods:/opt/hytale/mods
+      - /opt/hytale/plugins:/opt/hytale/plugins
 
       # Manager persistent data
       - manager-data:/app/data
 
     networks:
-      - hytale-beta-net
+      - hytale-net
 
     depends_on:
-      - hytale-beta
+      - hytale
 
     # Logging
     logging:
@@ -147,7 +147,7 @@ services:
 # Networks
 # ============================================================
 networks:
-  hytale-beta-net:
+  hytale-net:
     driver: bridge
 
 # ============================================================


### PR DESCRIPTION
Release out of beta:
- Renamed container from hytale-beta to hytale
- Renamed manager from hytale-beta-manager to hytale-manager
- Updated all host paths from /opt/hytale-beta/ to /opt/hytale/
- Updated network from hytale-beta-net to hytale-net
- Updated all documentation references