### PR TITLE
feat: add Quick Settings panel for common server config

### DIFF
--- a/manager/frontend/src/api/server.ts
+++ b/manager/frontend/src/api/server.ts
@@ -61,6 +61,15 @@ export interface ConfigContentResponse {
   content: string
 }
 
+export interface QuickSettings {
+  serverName: string
+  motd: string
+  password: string
+  maxPlayers: number
+  maxViewRadius: number
+  defaultGameMode: string
+}
+
 export const serverApi = {
   async getStatus(): Promise<ServerStatus> {
     const response = await api.get<ServerStatus>('/server/status')
@@ -104,6 +113,16 @@ export const serverApi = {
 
   async saveConfigContent(filename: string, content: string): Promise<ActionResponse> {
     const response = await api.put<ActionResponse>(`/server/config/${encodeURIComponent(filename)}`, { content })
+    return response.data
+  },
+
+  async getQuickSettings(): Promise<QuickSettings> {
+    const response = await api.get<QuickSettings>('/server/quick-settings')
+    return response.data
+  },
+
+  async saveQuickSettings(settings: Partial<QuickSettings>): Promise<ActionResponse> {
+    const response = await api.put<ActionResponse>('/server/quick-settings', settings)
     return response.data
   },
 }

--- a/manager/frontend/src/i18n/de.json
+++ b/manager/frontend/src/i18n/de.json
@@ -211,7 +211,18 @@
     "textEditor": "Text Editor",
     "saved": "Konfiguration erfolgreich gespeichert",
     "unsaved": "Ungespeicherte Änderungen",
-    "warning": "Achtung: Fehlerhafte Konfiguration kann den Server beschädigen. Nach dem Speichern ist ein Server-Neustart erforderlich."
+    "warning": "Achtung: Fehlerhafte Konfiguration kann den Server beschädigen. Nach dem Speichern ist ein Server-Neustart erforderlich.",
+    "quickSettings": "Schnelleinstellungen",
+    "serverName": "Server Name",
+    "serverNamePlaceholder": "Server Namen eingeben...",
+    "motd": "Nachricht des Tages (MOTD)",
+    "motdPlaceholder": "Willkommen auf unserem Server!",
+    "password": "Server Passwort",
+    "passwordPlaceholder": "Leer lassen für kein Passwort",
+    "passwordHint": "Leer lassen um jedem das Beitreten zu erlauben",
+    "maxPlayers": "Max. Spieler",
+    "maxViewRadius": "Sichtweite",
+    "defaultGameMode": "Standard Spielmodus"
   },
   "mods": {
     "title": "Mods & Plugins",

--- a/manager/frontend/src/i18n/en.json
+++ b/manager/frontend/src/i18n/en.json
@@ -211,7 +211,18 @@
     "textEditor": "Text Editor",
     "saved": "Configuration saved successfully",
     "unsaved": "Unsaved changes",
-    "warning": "Warning: Invalid configuration may break the server. A server restart is required after saving changes."
+    "warning": "Warning: Invalid configuration may break the server. A server restart is required after saving changes.",
+    "quickSettings": "Quick Settings",
+    "serverName": "Server Name",
+    "serverNamePlaceholder": "Enter server name...",
+    "motd": "Message of the Day (MOTD)",
+    "motdPlaceholder": "Welcome to our server!",
+    "password": "Server Password",
+    "passwordPlaceholder": "Leave empty for no password",
+    "passwordHint": "Leave empty to allow anyone to join",
+    "maxPlayers": "Max Players",
+    "maxViewRadius": "View Radius",
+    "defaultGameMode": "Default Gamemode"
   },
   "mods": {
     "title": "Mods & Plugins",


### PR DESCRIPTION
Add a user-friendly Quick Settings section in Configuration view that allows editing common server settings (ServerName, MOTD, Password, MaxPlayers, MaxViewRadius, DefaultGameMode) without editing JSON directly.

- Add backend API endpoints for quick-settings (GET/PUT)
- Add QuickSettings interface and API methods in frontend
- Add Quick Settings card with form inputs in Configuration.vue
- Add i18n translations for German and English