### PR TITLE
fix: improve mod config detection and fix Map icon visibility

### DIFF
--- a/manager/frontend/src/components/layout/Header.vue
+++ b/manager/frontend/src/components/layout/Header.vue
@@ -34,8 +34,8 @@ function openWebMap() {
 
 async function checkWebMapStatus() {
   try {
-    const mods = await modStoreApi.getAvailable()
-    const webMap = mods.find(m => m.id === 'easywebmap')
+    const result = await modStoreApi.getAvailable()
+    const webMap = result.mods.find(m => m.id === 'easywebmap')
     if (webMap && webMap.installed) {
       webMapInstalled.value = true
       // Get port from config if available


### PR DESCRIPTION
- Fix Header.vue to correctly access mods array from API response (result.mods instead of just mods)
- Add fuzzy config directory search to find folders like 'cryptobench_EasyWebMap' when searching for 'EasyWebMap'
- Extract base mod name without version for better matching
- Apply same fuzzy search logic to plugins config detection