### PR TITLE
fix: auth banner showing for already verified servers

### DIFF
--- a/manager/frontend/src/views/Dashboard.vue
+++ b/manager/frontend/src/views/Dashboard.vue
@@ -49,33 +49,33 @@ async function checkForUpdates() {
 
 async function checkHytaleAuth() {
   try {
-    const authStatus = await authApi.getHytaleAuthStatus()
-    hytaleAuthStatus.value = authStatus
-
     // Check if server is running
     if (status.value?.running) {
-      // Show banner if not authenticated
+      // First verify auth status with the backend
+      const checkResult = await authApi.checkHytaleAuthCompletion()
+
+      // Then get the updated status (which may have been modified by checkHytaleAuthCompletion)
+      const authStatus = await authApi.getHytaleAuthStatus()
+      hytaleAuthStatus.value = authStatus
+
+      // Show banner only if not authenticated
       if (!authStatus.authenticated) {
         showAuthBanner.value = true
         showMemoryOnlyWarning.value = false
       } else {
-        // Check if auth expired
-        const checkResult = await authApi.checkHytaleAuthCompletion()
-        if (!checkResult.success) {
-          showAuthBanner.value = true
-          showMemoryOnlyWarning.value = false
-        } else {
-          showAuthBanner.value = false
+        showAuthBanner.value = false
 
-          // Show memory-only warning if authenticated but not persistent
-          if (authStatus.persistenceType === 'memory' || (!authStatus.persistent && authStatus.authenticated)) {
-            showMemoryOnlyWarning.value = true
-          } else {
-            showMemoryOnlyWarning.value = false
-          }
+        // Show memory-only warning if authenticated but not persistent
+        if (authStatus.persistenceType === 'memory' || (!authStatus.persistent && authStatus.authenticated)) {
+          showMemoryOnlyWarning.value = true
+        } else {
+          showMemoryOnlyWarning.value = false
         }
       }
     } else {
+      // Server not running - just get the status without checking
+      const authStatus = await authApi.getHytaleAuthStatus()
+      hytaleAuthStatus.value = authStatus
       showAuthBanner.value = false
       showMemoryOnlyWarning.value = false
     }

--- a/manager/frontend/src/views/Settings.vue
+++ b/manager/frontend/src/views/Settings.vue
@@ -92,6 +92,10 @@ const hasChanges = () => fileContent.value !== originalContent.value
 // Hytale Auth Functions
 async function loadHytaleAuthStatus() {
   try {
+    // First verify auth status with the backend (this updates the stored status)
+    await authApi.checkHytaleAuthCompletion()
+
+    // Then get the updated status
     const status = await authApi.getHytaleAuthStatus()
     hytaleAuthStatus.value = status
   } catch (e) {


### PR DESCRIPTION
- Remove overly aggressive log patterns that caused false positives (e.g., "/auth login" pattern matched old log entries)
- Fix Dashboard.vue to sync auth status after checkHytaleAuthCompletion so the local state reflects the actual backend state
- Fix Settings.vue to verify auth status on load, ensuring the "Initiate Auth" button appears when auth is actually required
- Only invalidate token if there are actual auth failures, not just auth-required patterns which could be from previous sessions