### PR TITLE
fix: prevent server errors with large backup downloads

### DIFF
--- a/manager/backend/src/services/backup.ts
+++ b/manager/backend/src/services/backup.ts
@@ -112,8 +112,10 @@ export function createBackup(name?: string): ActionResponse & { backup?: BackupI
 
   try {
     // Create tarball using tar command (paths are validated, using single quotes for safety)
+    // Timeout increased to 30 minutes for large backups (1GB+)
     execSync(`tar -czf '${backupFile}' -C '${config.dataPath}' .`, {
-      timeout: 300000, // 5 minutes
+      timeout: 1800000, // 30 minutes
+      maxBuffer: 1024 * 1024 * 10, // 10MB buffer for command output
     });
 
     const stat = fs.statSync(backupFile);
@@ -188,8 +190,10 @@ export function restoreBackup(backupId: string): ActionResponse {
     fs.mkdirSync(tempDir, { recursive: true });
 
     // Extract backup (paths are validated, using single quotes for safety)
+    // Timeout increased to 30 minutes for large backups (1GB+)
     execSync(`tar -xzf '${filePath}' -C '${tempDir}'`, {
-      timeout: 300000,
+      timeout: 1800000, // 30 minutes
+      maxBuffer: 1024 * 1024 * 10, // 10MB buffer for command output
     });
 
     // Clear current data and move restored data


### PR DESCRIPTION
- Replace res.download() with fs.createReadStream().pipe(res) to prevent memory exhaustion when downloading large backups (1GB+)
- Increase backup create/restore timeout from 5 to 30 minutes
- Add maxBuffer option (10MB) for tar command output
- Add proper Content-Type, Content-Disposition, and Content-Length headers
- Add stream error handling for download failures