### PR TITLE
Fix offline users list showing empty when plugin is active

### DIFF
--- a/manager/backend/src/services/players.ts
+++ b/manager/backend/src/services/players.ts
@@ -93,6 +93,8 @@ export async function getPlayerHistory(): Promise<PlayerHistoryEntry[]> {
 
 export async function getOfflinePlayers(): Promise<PlayerHistoryEntry[]> {
   await loadPlayerHistory();
+  // Scan logs to ensure onlinePlayers map is up-to-date before filtering
+  await scanLogs();
   const onlineNames = new Set(onlinePlayers.keys());
   return Array.from(playerHistory.values())
     .filter(p => !onlineNames.has(p.name))


### PR DESCRIPTION
The getOfflinePlayers() function was not calling scanLogs() before filtering offline players. This caused issues when the plugin API was used for online players - the onlinePlayers map remained stale, leading to incorrect filtering and an empty offline users list.

Now scanLogs() is called in getOfflinePlayers() to ensure the onlinePlayers map is up-to-date before determining which players are offline.