### PR TITLE
Add patchline toggle to switch between release and pre-release

### DIFF
--- a/manager/frontend/src/api/server.ts
+++ b/manager/frontend/src/api/server.ts
@@ -74,6 +74,18 @@ export interface UpdateCheckResponse {
   installedVersion: string
   latestVersion: string
   updateAvailable: boolean
+  patchline?: string
+  message: string
+}
+
+export interface PatchlineResponse {
+  patchline: string
+  options: string[]
+}
+
+export interface PatchlineUpdateResponse {
+  success: boolean
+  patchline: string
   message: string
 }
 
@@ -199,6 +211,16 @@ export const serverApi = {
 
   async checkForUpdates(): Promise<UpdateCheckResponse> {
     const response = await api.get<UpdateCheckResponse>('/server/check-update')
+    return response.data
+  },
+
+  async getPatchline(): Promise<PatchlineResponse> {
+    const response = await api.get<PatchlineResponse>('/server/patchline')
+    return response.data
+  },
+
+  async setPatchline(patchline: string): Promise<PatchlineUpdateResponse> {
+    const response = await api.put<PatchlineUpdateResponse>('/server/patchline', { patchline })
     return response.data
   },
 

--- a/manager/frontend/src/i18n/de.json
+++ b/manager/frontend/src/i18n/de.json
@@ -407,7 +407,13 @@
     "authExpired": "Authentifizierungscode abgelaufen. Bitte erneut versuchen.",
     "openAuthUrl": "Authentifizierungsseite öffnen",
     "authCode": "Authentifizierungscode",
-    "copyCode": "Code kopieren"
+    "copyCode": "Code kopieren",
+    "patchlineTitle": "Server-Version (Patchline)",
+    "patchlineDesc": "Wähle zwischen der stabilen Release-Version oder der Pre-Release-Version für frühen Zugang zu neuen Features.",
+    "currentPatchline": "Aktuelle Patchline",
+    "patchlineReleaseDesc": "Stabil & empfohlen",
+    "patchlinePreReleaseDesc": "Früher Zugang, kann instabil sein",
+    "patchlineRestartNote": "Nach dem Ändern der Patchline muss der Server neugestartet werden, damit die Änderung wirksam wird."
   },
   "users": {
     "title": "Benutzerverwaltung",

--- a/manager/frontend/src/i18n/en.json
+++ b/manager/frontend/src/i18n/en.json
@@ -407,7 +407,13 @@
     "authExpired": "Authentication code expired. Please try again.",
     "openAuthUrl": "Open Authentication Page",
     "authCode": "Authentication Code",
-    "copyCode": "Copy Code"
+    "copyCode": "Copy Code",
+    "patchlineTitle": "Server Version (Patchline)",
+    "patchlineDesc": "Choose between the stable release version or the pre-release version for early access to new features.",
+    "currentPatchline": "Current Patchline",
+    "patchlineReleaseDesc": "Stable & recommended",
+    "patchlinePreReleaseDesc": "Early access, may be unstable",
+    "patchlineRestartNote": "After changing the patchline, the server must be restarted for the change to take effect."
   },
   "users": {
     "title": "User Management",

--- a/manager/frontend/src/i18n/pt_br.json
+++ b/manager/frontend/src/i18n/pt_br.json
@@ -407,7 +407,13 @@
     "authExpired": "Código de autenticação expirado. Por favor, tente novamente.",
     "openAuthUrl": "Abrir Página de Autenticação",
     "authCode": "Código de Autenticação",
-    "copyCode": "Copiar Código"
+    "copyCode": "Copiar Código",
+    "patchlineTitle": "Versão do Servidor (Patchline)",
+    "patchlineDesc": "Escolha entre a versão de lançamento estável ou a versão pre-release para acesso antecipado a novos recursos.",
+    "currentPatchline": "Patchline Atual",
+    "patchlineReleaseDesc": "Estável e recomendado",
+    "patchlinePreReleaseDesc": "Acesso antecipado, pode ser instável",
+    "patchlineRestartNote": "Após alterar a patchline, o servidor deve ser reiniciado para que a alteração tenha efeito."
   },
   "users": {
     "title": "Gerenciamento de Usuários",

--- a/manager/frontend/src/views/Settings.vue
+++ b/manager/frontend/src/views/Settings.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { setLocale, getLocale } from '@/i18n'
 import { useAuthStore } from '@/stores/auth'
 import Card from '@/components/ui/Card.vue'
-import { serverApi, type ConfigFile } from '@/api/server'
+import { serverApi, type ConfigFile, type PatchlineResponse } from '@/api/server'
 import { authApi, type HytaleAuthStatus, type HytaleDeviceCodeResponse } from '@/api/auth'
 
 const { t } = useI18n()
@@ -27,6 +27,12 @@ const hytaleAuthError = ref<string | null>(null)
 const hytaleAuthSuccess = ref<string | null>(null)
 const deviceCodeData = ref<HytaleDeviceCodeResponse | null>(null)
 const checkingInterval = ref<number | null>(null)
+
+// Patchline Settings
+const patchlineData = ref<PatchlineResponse | null>(null)
+const patchlineLoading = ref(false)
+const patchlineError = ref<string | null>(null)
+const patchlineSuccess = ref<string | null>(null)
 
 function changeLocale(locale: 'de' | 'en' | 'pt_br') {
   setLocale(locale)
@@ -88,6 +94,40 @@ function closeEditor() {
 }
 
 const hasChanges = () => fileContent.value !== originalContent.value
+
+// Patchline Functions
+async function loadPatchline() {
+  try {
+    patchlineLoading.value = true
+    patchlineError.value = null
+    const response = await serverApi.getPatchline()
+    patchlineData.value = response
+  } catch (e) {
+    patchlineError.value = 'Failed to load patchline setting'
+  } finally {
+    patchlineLoading.value = false
+  }
+}
+
+async function setPatchline(patchline: string) {
+  try {
+    patchlineLoading.value = true
+    patchlineError.value = null
+    patchlineSuccess.value = null
+
+    const response = await serverApi.setPatchline(patchline)
+
+    if (response.success) {
+      patchlineData.value = { ...patchlineData.value!, patchline: response.patchline }
+      patchlineSuccess.value = response.message
+      setTimeout(() => { patchlineSuccess.value = null }, 5000)
+    }
+  } catch (e) {
+    patchlineError.value = 'Failed to update patchline setting'
+  } finally {
+    patchlineLoading.value = false
+  }
+}
 
 // Hytale Auth Functions
 async function loadHytaleAuthStatus() {
@@ -216,6 +256,7 @@ onMounted(() => {
   // Load Hytale auth status if user can manage server
   if (authStore.canManageServer) {
     loadHytaleAuthStatus()
+    loadPatchline()
   }
 })
 
@@ -437,6 +478,92 @@ onUnmounted(() => {
             </div>
           </div>
         </div>
+      </div>
+    </Card>
+
+    <!-- Patchline Settings (admins and moderators only) -->
+    <Card v-if="authStore.canManageServer" :title="t('settings.patchlineTitle')">
+      <p class="text-gray-400 text-sm mb-4">{{ t('settings.patchlineDesc') }}</p>
+
+      <!-- Error/Success Messages -->
+      <div v-if="patchlineError" class="mb-4 p-3 bg-status-error/20 border border-status-error/30 rounded-lg text-status-error text-sm">
+        {{ patchlineError }}
+      </div>
+      <div v-if="patchlineSuccess" class="mb-4 p-3 bg-status-success/20 border border-status-success/30 rounded-lg text-status-success text-sm">
+        {{ patchlineSuccess }}
+      </div>
+
+      <div class="space-y-4">
+        <!-- Current Setting -->
+        <div class="flex items-center justify-between p-4 bg-dark-300 rounded-lg">
+          <div>
+            <p class="text-sm text-gray-400">{{ t('settings.currentPatchline') }}</p>
+            <p class="text-white font-medium mt-1 font-mono">
+              {{ patchlineData?.patchline || '-' }}
+            </p>
+          </div>
+        </div>
+
+        <!-- Patchline Selection -->
+        <div v-if="!patchlineLoading" class="flex gap-4">
+          <button
+            @click="setPatchline('release')"
+            :disabled="patchlineLoading"
+            :class="[
+              'flex-1 flex items-center justify-center gap-3 px-4 py-3 rounded-lg border-2 transition-all',
+              patchlineData?.patchline === 'release'
+                ? 'border-status-success bg-status-success/10'
+                : 'border-dark-50 hover:border-gray-600'
+            ]"
+          >
+            <div class="text-center">
+              <p class="font-medium text-white">Release</p>
+              <p class="text-xs text-gray-400">{{ t('settings.patchlineReleaseDesc') }}</p>
+            </div>
+            <svg
+              v-if="patchlineData?.patchline === 'release'"
+              class="w-5 h-5 text-status-success"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+          </button>
+
+          <button
+            @click="setPatchline('pre-release')"
+            :disabled="patchlineLoading"
+            :class="[
+              'flex-1 flex items-center justify-center gap-3 px-4 py-3 rounded-lg border-2 transition-all',
+              patchlineData?.patchline === 'pre-release'
+                ? 'border-status-warning bg-status-warning/10'
+                : 'border-dark-50 hover:border-gray-600'
+            ]"
+          >
+            <div class="text-center">
+              <p class="font-medium text-white">Pre-Release</p>
+              <p class="text-xs text-gray-400">{{ t('settings.patchlinePreReleaseDesc') }}</p>
+            </div>
+            <svg
+              v-if="patchlineData?.patchline === 'pre-release'"
+              class="w-5 h-5 text-status-warning"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+          </button>
+        </div>
+
+        <div v-else class="text-center py-4 text-gray-400">
+          {{ t('common.loading') }}...
+        </div>
+
+        <p class="text-xs text-gray-500">
+          {{ t('settings.patchlineRestartNote') }}
+        </p>
       </div>
     </Card>
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -64,6 +64,24 @@ ASSETS_FILE="/opt/hytale/server/Assets.zip"
 DOWNLOADER_DIR="/opt/hytale/downloader"
 CREDENTIALS_FILE="${DOWNLOADER_DIR}/.hytale-downloader-credentials.json"
 
+# Function to get patchline from panel config or env
+get_patchline() {
+    PANEL_CONFIG="/opt/hytale/data/panel-config.json"
+
+    # First try to read from panel config file
+    if [ -f "$PANEL_CONFIG" ]; then
+        # Extract patchline value from JSON using grep/sed (jq might not be available)
+        PANEL_PATCHLINE=$(cat "$PANEL_CONFIG" 2>/dev/null | grep -o '"patchline"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"patchline"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+        if [ -n "$PANEL_PATCHLINE" ]; then
+            echo "$PANEL_PATCHLINE"
+            return
+        fi
+    fi
+
+    # Fallback to environment variable or default
+    echo "${HYTALE_PATCHLINE:-release}"
+}
+
 # Function to run Hytale Downloader
 run_downloader() {
     local UPDATE_MODE="$1"
@@ -84,7 +102,8 @@ run_downloader() {
     fi
 
     cd "$DOWNLOADER_DIR"
-    PATCHLINE="${HYTALE_PATCHLINE:-release}"
+    PATCHLINE=$(get_patchline)
+    echo "[INFO] Using patchline: $PATCHLINE"
     DOWNLOAD_PATH="/opt/hytale/server/game.zip"
     VERSION_FILE="/opt/hytale/server/.hytale-version"
 


### PR DESCRIPTION
- Add backend API endpoints GET/PUT /api/server/patchline
- Store patchline setting in /opt/hytale/data/panel-config.json
- Add patchline toggle UI in Settings page
- Update entrypoint.sh to read panel config with .env fallback
- Fix hardcoded patchline in check-update endpoint
- Add translations for DE, EN, PT-BR