### PR TITLE
Add reverse proxy support for domain routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,15 @@ JWT_SECRET=bitte-aendern-sicherer-geheimer-schluessel
 # ====================
 MANAGER_PORT=18080
 
+# ====================
+# Reverse Proxy
+# ====================
+# Setze auf true, wenn der Manager hinter einem Reverse Proxy
+# (nginx, traefik, caddy, etc.) laeuft.
+# Erforderlich fuer HTTPS via Domain (z.B. manager.example.com)
+# Aktiviert korrekte Verarbeitung von X-Forwarded-* Headers
+TRUST_PROXY=false
+
 # ============================================================
 # EASYWEBMAP - Live Server Karte (Optional)
 # ============================================================

--- a/manager/backend/src/config.ts
+++ b/manager/backend/src/config.ts
@@ -30,6 +30,11 @@ export const config = {
   port: parseInt(process.env.MANAGER_PORT || '18080', 10),
   corsOrigins: process.env.CORS_ORIGINS || '*',
 
+  // Reverse Proxy Support
+  // Set to true/1 when running behind a reverse proxy (nginx, traefik, etc.)
+  // This enables proper handling of X-Forwarded-* headers
+  trustProxy: process.env.TRUST_PROXY === 'true' || process.env.TRUST_PROXY === '1',
+
   // Timezone
   tz: process.env.TZ || 'Europe/Berlin',
 

--- a/manager/backend/src/index.ts
+++ b/manager/backend/src/index.ts
@@ -28,6 +28,13 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const server = createServer(app);
 
+// Reverse Proxy Support - must be set before other middleware
+// This enables proper handling of X-Forwarded-* headers when behind nginx, traefik, etc.
+if (config.trustProxy) {
+  app.set('trust proxy', 1);
+  console.log('Reverse proxy mode enabled (TRUST_PROXY=true)');
+}
+
 // WebSocket server
 const wss = new WebSocketServer({ server, path: '/api/console/ws' });
 setupWebSocket(wss);


### PR DESCRIPTION
Add TRUST_PROXY environment variable to enable proper handling of X-Forwarded-* headers when running behind nginx, traefik, or other reverse proxies. This fixes HTTPS domain routing for the manager (e.g., manager.example.com -> port 18080).

The map server (EasyWebMap) already works because it's a simpler static server. The manager requires explicit proxy trust configuration due to its WebSocket authentication and Express middleware stack.