### PR TITLE
feat: Add Asset Explorer for browsing Hytale game assets

### DIFF
--- a/manager/backend/src/config.ts
+++ b/manager/backend/src/config.ts
@@ -25,6 +25,7 @@ export const config = {
   dataPath: process.env.DATA_PATH || '/opt/hytale/data',
   modsPath: process.env.MODS_PATH || '/opt/hytale/mods',
   pluginsPath: process.env.PLUGINS_PATH || '/opt/hytale/plugins',
+  assetsPath: process.env.ASSETS_PATH || '/opt/hytale/assets', // Extracted assets cache (not backed up)
 
   // Server
   port: parseInt(process.env.MANAGER_PORT || '18080', 10),

--- a/manager/backend/src/index.ts
+++ b/manager/backend/src/index.ts
@@ -18,6 +18,7 @@ import backupRoutes from './routes/backup.js';
 import playersRoutes from './routes/players.js';
 import managementRoutes from './routes/management.js';
 import schedulerRoutes from './routes/scheduler.js';
+import assetsRoutes from './routes/assets.js';
 
 // Services
 import { startSchedulers } from './services/scheduler.js';
@@ -59,6 +60,7 @@ app.use('/api/backups', backupRoutes);
 app.use('/api/players', playersRoutes);
 app.use('/api/management', managementRoutes);
 app.use('/api/scheduler', schedulerRoutes);
+app.use('/api/assets', assetsRoutes);
 
 // Health check
 app.get('/api/health', (_req, res) => {

--- a/manager/backend/src/routes/assets.ts
+++ b/manager/backend/src/routes/assets.ts
@@ -1,0 +1,158 @@
+import { Router, Request, Response } from 'express';
+import { authMiddleware } from '../middleware/auth.js';
+import * as assetService from '../services/assets.js';
+
+const router = Router();
+
+// GET /api/assets/status - Get extraction status
+router.get('/status', authMiddleware, (_req: Request, res: Response) => {
+  const status = assetService.getAssetStatus();
+  res.json(status);
+});
+
+// POST /api/assets/extract - Extract assets from archive
+router.post('/extract', authMiddleware, (_req: Request, res: Response) => {
+  const result = assetService.extractAssets();
+
+  if (!result.success) {
+    res.status(500).json(result);
+    return;
+  }
+
+  res.json({
+    success: true,
+    message: `Assets extracted successfully (${result.fileCount} files)`,
+    fileCount: result.fileCount,
+  });
+});
+
+// DELETE /api/assets/cache - Clear extracted assets
+router.delete('/cache', authMiddleware, (_req: Request, res: Response) => {
+  const result = assetService.clearAssets();
+
+  if (!result.success) {
+    res.status(500).json(result);
+    return;
+  }
+
+  res.json({
+    success: true,
+    message: 'Asset cache cleared',
+  });
+});
+
+// GET /api/assets/browse - List directory contents
+router.get('/browse', authMiddleware, (req: Request, res: Response) => {
+  const relativePath = (req.query.path as string) || '';
+
+  const items = assetService.listAssetDirectory(relativePath);
+
+  if (items === null) {
+    res.status(404).json({ detail: 'Directory not found or invalid path' });
+    return;
+  }
+
+  res.json({
+    path: relativePath,
+    items,
+  });
+});
+
+// GET /api/assets/tree - Get directory tree
+router.get('/tree', authMiddleware, (req: Request, res: Response) => {
+  const relativePath = (req.query.path as string) || '';
+  const maxDepth = Math.min(parseInt(req.query.depth as string) || 3, 5);
+
+  const tree = assetService.getAssetTree(relativePath, maxDepth);
+
+  if (tree === null) {
+    res.status(404).json({ detail: 'Directory not found or invalid path' });
+    return;
+  }
+
+  res.json(tree);
+});
+
+// GET /api/assets/file - Read file content
+router.get('/file', authMiddleware, (req: Request, res: Response) => {
+  const relativePath = req.query.path as string;
+
+  if (!relativePath) {
+    res.status(400).json({ detail: 'Path parameter required' });
+    return;
+  }
+
+  const result = assetService.readAssetFile(relativePath);
+
+  if (!result.success) {
+    res.status(404).json({ detail: result.error });
+    return;
+  }
+
+  res.json({
+    path: relativePath,
+    content: result.content,
+    mimeType: result.mimeType,
+    size: result.size,
+    isBinary: result.isBinary,
+  });
+});
+
+// GET /api/assets/search - Search for files
+router.get('/search', authMiddleware, (req: Request, res: Response) => {
+  const query = req.query.q as string;
+
+  if (!query || query.length < 2) {
+    res.status(400).json({ detail: 'Search query must be at least 2 characters' });
+    return;
+  }
+
+  const searchContent = req.query.content === 'true';
+  const extensions = req.query.ext ? (req.query.ext as string).split(',') : undefined;
+  const maxResults = Math.min(parseInt(req.query.limit as string) || 100, 500);
+
+  const results = assetService.searchAssets(query, {
+    searchContent,
+    extensions,
+    maxResults,
+  });
+
+  res.json({
+    query,
+    count: results.length,
+    results,
+  });
+});
+
+// GET /api/assets/download/:path(*) - Download raw file
+router.get('/download/*', authMiddleware, (req: Request, res: Response) => {
+  const relativePath = req.params[0];
+
+  if (!relativePath) {
+    res.status(400).json({ detail: 'Path parameter required' });
+    return;
+  }
+
+  const result = assetService.readAssetFile(relativePath);
+
+  if (!result.success) {
+    res.status(404).json({ detail: result.error });
+    return;
+  }
+
+  const filename = relativePath.split('/').pop() || 'file';
+
+  if (result.isBinary && result.mimeType?.startsWith('image/')) {
+    // Send actual image file
+    res.setHeader('Content-Type', result.mimeType);
+    res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
+    res.send(Buffer.from(result.content as string, 'base64'));
+  } else {
+    // Send as download
+    res.setHeader('Content-Type', result.mimeType || 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(result.content);
+  }
+});
+
+export default router;

--- a/manager/backend/src/services/assets.ts
+++ b/manager/backend/src/services/assets.ts
@@ -1,0 +1,594 @@
+/**
+ * Asset Service
+ * Handles extraction, browsing, and reading of Hytale game assets
+ * Assets are extracted to a separate directory (not backed up)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import crypto from 'crypto';
+import { config } from '../config.js';
+import { isPathSafe, safePathJoin } from '../utils/pathSecurity.js';
+
+// Asset metadata file to track extraction state
+const ASSET_META_FILE = '.asset-meta.json';
+
+interface AssetMeta {
+  sourceHash: string;
+  extractedAt: string;
+  sourceFile: string;
+  fileCount: number;
+}
+
+interface AssetFileInfo {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  size: number;
+  lastModified: string;
+  extension?: string;
+}
+
+interface AssetTreeNode {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  size: number;
+  extension?: string;
+  children?: AssetTreeNode[];
+}
+
+interface AssetStatus {
+  extracted: boolean;
+  sourceExists: boolean;
+  sourceFile: string | null;
+  extractedAt: string | null;
+  fileCount: number;
+  needsUpdate: boolean;
+  totalSize: number;
+}
+
+interface SearchResult {
+  path: string;
+  name: string;
+  type: 'file' | 'directory';
+  size: number;
+  extension?: string;
+  matchType: 'filename' | 'content';
+  contentPreview?: string;
+}
+
+/**
+ * Find the Assets.zip file in the server directory
+ */
+export function findAssetsArchive(): string | null {
+  const possibleNames = ['Assets.zip', 'assets.zip', 'ASSETS.ZIP'];
+
+  for (const name of possibleNames) {
+    const archivePath = path.join(config.serverPath, name);
+    if (fs.existsSync(archivePath)) {
+      return archivePath;
+    }
+  }
+
+  // Also check in data directory
+  for (const name of possibleNames) {
+    const archivePath = path.join(config.dataPath, name);
+    if (fs.existsSync(archivePath)) {
+      return archivePath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Calculate hash of the assets archive for version tracking
+ */
+function calculateFileHash(filePath: string): string {
+  const fileBuffer = fs.readFileSync(filePath);
+  const hashSum = crypto.createHash('sha256');
+  hashSum.update(fileBuffer);
+  return hashSum.digest('hex').substring(0, 16); // Short hash is sufficient
+}
+
+/**
+ * Read asset metadata
+ */
+function readAssetMeta(): AssetMeta | null {
+  const metaPath = path.join(config.assetsPath, ASSET_META_FILE);
+  if (!fs.existsSync(metaPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(metaPath, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write asset metadata
+ */
+function writeAssetMeta(meta: AssetMeta): void {
+  const metaPath = path.join(config.assetsPath, ASSET_META_FILE);
+  fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+}
+
+/**
+ * Count files in a directory recursively
+ */
+function countFiles(dirPath: string): number {
+  let count = 0;
+
+  try {
+    const items = fs.readdirSync(dirPath);
+    for (const item of items) {
+      if (item.startsWith('.')) continue;
+      const itemPath = path.join(dirPath, item);
+      const stat = fs.statSync(itemPath);
+      if (stat.isFile()) {
+        count++;
+      } else if (stat.isDirectory()) {
+        count += countFiles(itemPath);
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+
+  return count;
+}
+
+/**
+ * Get total size of a directory
+ */
+function getDirectorySize(dirPath: string): number {
+  let size = 0;
+
+  try {
+    const items = fs.readdirSync(dirPath);
+    for (const item of items) {
+      if (item.startsWith('.')) continue;
+      const itemPath = path.join(dirPath, item);
+      const stat = fs.statSync(itemPath);
+      if (stat.isFile()) {
+        size += stat.size;
+      } else if (stat.isDirectory()) {
+        size += getDirectorySize(itemPath);
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+
+  return size;
+}
+
+/**
+ * Get status of the asset extraction
+ */
+export function getAssetStatus(): AssetStatus {
+  const sourceFile = findAssetsArchive();
+  const meta = readAssetMeta();
+
+  let needsUpdate = false;
+
+  if (sourceFile && meta) {
+    const currentHash = calculateFileHash(sourceFile);
+    needsUpdate = currentHash !== meta.sourceHash;
+  }
+
+  return {
+    extracted: meta !== null && fs.existsSync(config.assetsPath),
+    sourceExists: sourceFile !== null,
+    sourceFile: sourceFile,
+    extractedAt: meta?.extractedAt || null,
+    fileCount: meta?.fileCount || 0,
+    needsUpdate: needsUpdate,
+    totalSize: fs.existsSync(config.assetsPath) ? getDirectorySize(config.assetsPath) : 0,
+  };
+}
+
+/**
+ * Extract assets from the archive
+ */
+export function extractAssets(): { success: boolean; error?: string; fileCount?: number } {
+  const sourceFile = findAssetsArchive();
+
+  if (!sourceFile) {
+    return { success: false, error: 'Assets.zip not found in server or data directory' };
+  }
+
+  try {
+    // Create assets directory if it doesn't exist
+    if (!fs.existsSync(config.assetsPath)) {
+      fs.mkdirSync(config.assetsPath, { recursive: true });
+    }
+
+    // Clear existing assets (except meta file)
+    const existingItems = fs.readdirSync(config.assetsPath);
+    for (const item of existingItems) {
+      if (item === ASSET_META_FILE) continue;
+      const itemPath = path.join(config.assetsPath, item);
+      fs.rmSync(itemPath, { recursive: true, force: true });
+    }
+
+    // Extract using unzip command
+    // Timeout of 10 minutes for large archives
+    execSync(`unzip -q -o '${sourceFile}' -d '${config.assetsPath}'`, {
+      timeout: 600000, // 10 minutes
+      maxBuffer: 1024 * 1024 * 50, // 50MB buffer
+    });
+
+    // Count extracted files
+    const fileCount = countFiles(config.assetsPath);
+
+    // Calculate hash and save metadata
+    const sourceHash = calculateFileHash(sourceFile);
+    writeAssetMeta({
+      sourceHash,
+      extractedAt: new Date().toISOString(),
+      sourceFile: sourceFile,
+      fileCount,
+    });
+
+    return { success: true, fileCount };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Extraction failed'
+    };
+  }
+}
+
+/**
+ * Delete extracted assets (clear cache)
+ */
+export function clearAssets(): { success: boolean; error?: string } {
+  try {
+    if (fs.existsSync(config.assetsPath)) {
+      fs.rmSync(config.assetsPath, { recursive: true, force: true });
+    }
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to clear assets'
+    };
+  }
+}
+
+/**
+ * List files in a directory within the assets
+ */
+export function listAssetDirectory(relativePath: string = ''): AssetFileInfo[] | null {
+  const targetPath = safePathJoin(config.assetsPath, relativePath);
+
+  if (!targetPath || !isPathSafe(targetPath, [config.assetsPath])) {
+    return null;
+  }
+
+  if (!fs.existsSync(targetPath)) {
+    return null;
+  }
+
+  const stat = fs.statSync(targetPath);
+  if (!stat.isDirectory()) {
+    return null;
+  }
+
+  const items: AssetFileInfo[] = [];
+  const entries = fs.readdirSync(targetPath);
+
+  for (const entry of entries) {
+    if (entry.startsWith('.')) continue;
+
+    const entryPath = path.join(targetPath, entry);
+    const entryRelPath = relativePath ? `${relativePath}/${entry}` : entry;
+
+    try {
+      const entryStat = fs.statSync(entryPath);
+      const isDir = entryStat.isDirectory();
+
+      items.push({
+        name: entry,
+        path: entryRelPath,
+        type: isDir ? 'directory' : 'file',
+        size: isDir ? 0 : entryStat.size,
+        lastModified: entryStat.mtime.toISOString(),
+        extension: isDir ? undefined : path.extname(entry).toLowerCase(),
+      });
+    } catch {
+      // Skip entries we can't read
+      continue;
+    }
+  }
+
+  // Sort: directories first, then files, alphabetically
+  items.sort((a, b) => {
+    if (a.type !== b.type) {
+      return a.type === 'directory' ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  return items;
+}
+
+/**
+ * Get asset directory tree (recursive, with depth limit)
+ */
+export function getAssetTree(relativePath: string = '', maxDepth: number = 3): AssetTreeNode | null {
+  const targetPath = safePathJoin(config.assetsPath, relativePath);
+
+  if (!targetPath || !isPathSafe(targetPath, [config.assetsPath])) {
+    return null;
+  }
+
+  if (!fs.existsSync(targetPath)) {
+    return null;
+  }
+
+  function buildTree(dirPath: string, relPath: string, depth: number): AssetTreeNode {
+    const stat = fs.statSync(dirPath);
+    const name = path.basename(dirPath) || 'Assets';
+
+    if (stat.isFile()) {
+      return {
+        name,
+        path: relPath,
+        type: 'file',
+        size: stat.size,
+        extension: path.extname(name).toLowerCase(),
+      };
+    }
+
+    const node: AssetTreeNode = {
+      name,
+      path: relPath,
+      type: 'directory',
+      size: 0,
+      children: [],
+    };
+
+    if (depth < maxDepth) {
+      try {
+        const entries = fs.readdirSync(dirPath);
+        for (const entry of entries) {
+          if (entry.startsWith('.')) continue;
+
+          const entryPath = path.join(dirPath, entry);
+          const entryRelPath = relPath ? `${relPath}/${entry}` : entry;
+
+          node.children!.push(buildTree(entryPath, entryRelPath, depth + 1));
+        }
+
+        // Sort children
+        node.children!.sort((a, b) => {
+          if (a.type !== b.type) {
+            return a.type === 'directory' ? -1 : 1;
+          }
+          return a.name.localeCompare(b.name);
+        });
+      } catch {
+        // Ignore errors
+      }
+    }
+
+    return node;
+  }
+
+  return buildTree(targetPath, relativePath, 0);
+}
+
+/**
+ * Read file content from assets
+ */
+export function readAssetFile(relativePath: string): {
+  success: boolean;
+  content?: string | Buffer;
+  mimeType?: string;
+  size?: number;
+  error?: string;
+  isBinary?: boolean;
+} {
+  const targetPath = safePathJoin(config.assetsPath, relativePath);
+
+  if (!targetPath || !isPathSafe(targetPath, [config.assetsPath])) {
+    return { success: false, error: 'Invalid path' };
+  }
+
+  if (!fs.existsSync(targetPath)) {
+    return { success: false, error: 'File not found' };
+  }
+
+  const stat = fs.statSync(targetPath);
+  if (!stat.isFile()) {
+    return { success: false, error: 'Not a file' };
+  }
+
+  // Determine file type
+  const ext = path.extname(relativePath).toLowerCase();
+  const textExtensions = ['.json', '.txt', '.xml', '.yml', '.yaml', '.cfg', '.conf', '.properties', '.md', '.lua', '.js', '.ts', '.css', '.html', '.csv', '.ini', '.log'];
+  const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg'];
+
+  const isText = textExtensions.includes(ext);
+  const isImage = imageExtensions.includes(ext);
+
+  // Limit file size for reading (10MB for text, 50MB for binary)
+  const maxSize = isText ? 10 * 1024 * 1024 : 50 * 1024 * 1024;
+  if (stat.size > maxSize) {
+    return { success: false, error: `File too large (max ${maxSize / 1024 / 1024}MB)` };
+  }
+
+  try {
+    if (isImage) {
+      // Return base64 encoded image
+      const content = fs.readFileSync(targetPath);
+      const mimeTypes: Record<string, string> = {
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif',
+        '.webp': 'image/webp',
+        '.bmp': 'image/bmp',
+        '.ico': 'image/x-icon',
+        '.svg': 'image/svg+xml',
+      };
+
+      return {
+        success: true,
+        content: content.toString('base64'),
+        mimeType: mimeTypes[ext] || 'application/octet-stream',
+        size: stat.size,
+        isBinary: true,
+      };
+    } else if (isText) {
+      // Return text content
+      const content = fs.readFileSync(targetPath, 'utf-8');
+      return {
+        success: true,
+        content,
+        mimeType: ext === '.json' ? 'application/json' : 'text/plain',
+        size: stat.size,
+        isBinary: false,
+      };
+    } else {
+      // Return hex preview for binary files
+      const content = fs.readFileSync(targetPath);
+      const hexPreview = content.subarray(0, 1024).toString('hex').match(/.{1,2}/g)?.join(' ') || '';
+
+      return {
+        success: true,
+        content: hexPreview,
+        mimeType: 'application/octet-stream',
+        size: stat.size,
+        isBinary: true,
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to read file'
+    };
+  }
+}
+
+/**
+ * Search for files in assets
+ */
+export function searchAssets(query: string, options?: {
+  searchContent?: boolean;
+  extensions?: string[];
+  maxResults?: number;
+}): SearchResult[] {
+  const results: SearchResult[] = [];
+  const maxResults = options?.maxResults || 100;
+  const searchContent = options?.searchContent || false;
+  const extensions = options?.extensions;
+  const queryLower = query.toLowerCase();
+
+  function searchDir(dirPath: string, relativePath: string): void {
+    if (results.length >= maxResults) return;
+
+    try {
+      const entries = fs.readdirSync(dirPath);
+
+      for (const entry of entries) {
+        if (results.length >= maxResults) break;
+        if (entry.startsWith('.')) continue;
+
+        const entryPath = path.join(dirPath, entry);
+        const entryRelPath = relativePath ? `${relativePath}/${entry}` : entry;
+
+        try {
+          const stat = fs.statSync(entryPath);
+          const ext = path.extname(entry).toLowerCase();
+
+          // Filter by extension if specified
+          if (extensions && extensions.length > 0 && stat.isFile()) {
+            if (!extensions.includes(ext)) continue;
+          }
+
+          // Check filename match
+          if (entry.toLowerCase().includes(queryLower)) {
+            results.push({
+              path: entryRelPath,
+              name: entry,
+              type: stat.isDirectory() ? 'directory' : 'file',
+              size: stat.isFile() ? stat.size : 0,
+              extension: stat.isFile() ? ext : undefined,
+              matchType: 'filename',
+            });
+          }
+
+          // Search content for text files
+          if (searchContent && stat.isFile() && stat.size < 1024 * 1024) { // Max 1MB for content search
+            const textExtensions = ['.json', '.txt', '.xml', '.yml', '.yaml', '.cfg', '.lua', '.js'];
+            if (textExtensions.includes(ext)) {
+              try {
+                const content = fs.readFileSync(entryPath, 'utf-8');
+                const lowerContent = content.toLowerCase();
+                const matchIndex = lowerContent.indexOf(queryLower);
+
+                if (matchIndex !== -1) {
+                  // Get preview around match
+                  const start = Math.max(0, matchIndex - 50);
+                  const end = Math.min(content.length, matchIndex + query.length + 50);
+                  const preview = (start > 0 ? '...' : '') +
+                                  content.substring(start, end) +
+                                  (end < content.length ? '...' : '');
+
+                  // Avoid duplicate if already matched by filename
+                  if (!results.some(r => r.path === entryRelPath)) {
+                    results.push({
+                      path: entryRelPath,
+                      name: entry,
+                      type: 'file',
+                      size: stat.size,
+                      extension: ext,
+                      matchType: 'content',
+                      contentPreview: preview.replace(/\n/g, ' '),
+                    });
+                  }
+                }
+              } catch {
+                // Skip files that can't be read as text
+              }
+            }
+          }
+
+          // Recurse into directories
+          if (stat.isDirectory()) {
+            searchDir(entryPath, entryRelPath);
+          }
+        } catch {
+          // Skip entries we can't read
+        }
+      }
+    } catch {
+      // Ignore directory read errors
+    }
+  }
+
+  if (fs.existsSync(config.assetsPath)) {
+    searchDir(config.assetsPath, '');
+  }
+
+  return results;
+}
+
+export default {
+  findAssetsArchive,
+  getAssetStatus,
+  extractAssets,
+  clearAssets,
+  listAssetDirectory,
+  getAssetTree,
+  readAssetFile,
+  searchAssets,
+};

--- a/manager/frontend/src/api/assets.ts
+++ b/manager/frontend/src/api/assets.ts
@@ -1,0 +1,111 @@
+import api from './client'
+
+// Extended timeout for extraction (10 minutes)
+const EXTRACT_TIMEOUT = 10 * 60 * 1000
+
+export interface AssetStatus {
+  extracted: boolean
+  sourceExists: boolean
+  sourceFile: string | null
+  extractedAt: string | null
+  fileCount: number
+  needsUpdate: boolean
+  totalSize: number
+}
+
+export interface AssetFileInfo {
+  name: string
+  path: string
+  type: 'file' | 'directory'
+  size: number
+  lastModified: string
+  extension?: string
+}
+
+export interface AssetTreeNode {
+  name: string
+  path: string
+  type: 'file' | 'directory'
+  size: number
+  extension?: string
+  children?: AssetTreeNode[]
+}
+
+export interface SearchResult {
+  path: string
+  name: string
+  type: 'file' | 'directory'
+  size: number
+  extension?: string
+  matchType: 'filename' | 'content'
+  contentPreview?: string
+}
+
+export interface FileContent {
+  path: string
+  content: string
+  mimeType: string
+  size: number
+  isBinary: boolean
+}
+
+export const assetsApi = {
+  async getStatus(): Promise<AssetStatus> {
+    const response = await api.get<AssetStatus>('/assets/status')
+    return response.data
+  },
+
+  async extract(): Promise<{ success: boolean; message: string; fileCount?: number }> {
+    const response = await api.post('/assets/extract', {}, {
+      timeout: EXTRACT_TIMEOUT,
+    })
+    return response.data
+  },
+
+  async clearCache(): Promise<{ success: boolean; message: string }> {
+    const response = await api.delete('/assets/cache')
+    return response.data
+  },
+
+  async browse(path: string = ''): Promise<{ path: string; items: AssetFileInfo[] }> {
+    const response = await api.get('/assets/browse', {
+      params: { path },
+    })
+    return response.data
+  },
+
+  async getTree(path: string = '', depth: number = 3): Promise<AssetTreeNode> {
+    const response = await api.get<AssetTreeNode>('/assets/tree', {
+      params: { path, depth },
+    })
+    return response.data
+  },
+
+  async readFile(path: string): Promise<FileContent> {
+    const response = await api.get<FileContent>('/assets/file', {
+      params: { path },
+    })
+    return response.data
+  },
+
+  async search(
+    query: string,
+    options?: {
+      searchContent?: boolean
+      extensions?: string[]
+      limit?: number
+    }
+  ): Promise<{ query: string; count: number; results: SearchResult[] }> {
+    const params: Record<string, string> = { q: query }
+    if (options?.searchContent) params.content = 'true'
+    if (options?.extensions) params.ext = options.extensions.join(',')
+    if (options?.limit) params.limit = String(options.limit)
+
+    const response = await api.get('/assets/search', { params })
+    return response.data
+  },
+
+  getDownloadUrl(path: string): string {
+    return `/api/assets/download/${path}`
+  },
+}

--- a/manager/frontend/src/components/layout/Sidebar.vue
+++ b/manager/frontend/src/components/layout/Sidebar.vue
@@ -43,6 +43,7 @@ const navItems = computed<NavItem[]>(() => [
   { name: 'permissions', path: '/permissions', icon: 'permissions', label: t('nav.permissions'), group: 'management', permission: 'managePlayers' },
   { name: 'worlds', path: '/worlds', icon: 'worlds', label: t('nav.worlds'), group: 'management', permission: 'managePlayers' },
   { name: 'mods', path: '/mods', icon: 'mods', label: t('nav.mods'), group: 'management', permission: 'managePlayers' },
+  { name: 'assets', path: '/assets', icon: 'assets', label: t('nav.assets'), group: 'management', permission: 'managePlayers' },
   { name: 'backups', path: '/backups', icon: 'backup', label: t('nav.backups'), group: 'data', permission: 'manageBackups' },
   { name: 'scheduler', path: '/scheduler', icon: 'scheduler', label: t('nav.scheduler'), group: 'data', permission: 'manageBackups' },
   { name: 'configuration', path: '/configuration', icon: 'configuration', label: t('nav.configuration'), group: 'data', permission: 'manageConfig' },
@@ -152,6 +153,11 @@ function isActive(path: string): boolean {
             <!-- Mods Icon -->
             <svg v-else-if="item.icon === 'mods'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+            </svg>
+
+            <!-- Assets Icon -->
+            <svg v-else-if="item.icon === 'assets'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z" />
             </svg>
 
             <span>{{ item.label }}</span>

--- a/manager/frontend/src/i18n/de.json
+++ b/manager/frontend/src/i18n/de.json
@@ -49,7 +49,8 @@
     "management": "Verwaltung",
     "data": "Daten",
     "scheduler": "Planer",
-    "statistics": "Statistiken"
+    "statistics": "Statistiken",
+    "assets": "Asset Explorer"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -613,5 +614,55 @@
     "notInstalled": "EasyWebMap nicht installiert",
     "notInstalledDesc": "Das EasyWebMap-Mod ist nicht installiert. Installiere es über den Mod Store, um die Live-Webkarte zu aktivieren.",
     "goToModStore": "Zum Mod Store"
+  },
+  "assets": {
+    "title": "Asset Explorer",
+    "subtitle": "Hytale Spiel-Assets durchsuchen und analysieren",
+    "status": "Status",
+    "extracted": "Entpackt",
+    "notExtracted": "Nicht entpackt",
+    "sourceFile": "Quelldatei",
+    "sourceNotFound": "Assets.zip nicht gefunden",
+    "fileCount": "Dateien",
+    "totalSize": "Gesamtgröße",
+    "extractedAt": "Entpackt am",
+    "needsUpdate": "Update verfügbar",
+    "extract": "Assets entpacken",
+    "extracting": "Entpacke...",
+    "reExtract": "Neu entpacken",
+    "clearCache": "Cache leeren",
+    "clearing": "Lösche...",
+    "extractSuccess": "Assets erfolgreich entpackt",
+    "clearSuccess": "Asset-Cache gelöscht",
+    "browse": "Durchsuchen",
+    "search": "Suchen",
+    "searchPlaceholder": "Dateien suchen...",
+    "searchContent": "Auch in Dateiinhalt suchen",
+    "noResults": "Keine Ergebnisse",
+    "noFiles": "Keine Dateien in diesem Ordner",
+    "file": "Datei",
+    "folder": "Ordner",
+    "size": "Größe",
+    "modified": "Geändert",
+    "path": "Pfad",
+    "preview": "Vorschau",
+    "download": "Herunterladen",
+    "copyPath": "Pfad kopieren",
+    "backToParent": "Übergeordneter Ordner",
+    "root": "Wurzelverzeichnis",
+    "viewer": {
+      "json": "JSON Viewer",
+      "image": "Bildvorschau",
+      "text": "Text Viewer",
+      "hex": "Hex Viewer",
+      "unsupported": "Vorschau nicht verfügbar"
+    },
+    "filters": {
+      "all": "Alle Dateien",
+      "json": "JSON Dateien",
+      "images": "Bilder",
+      "text": "Text Dateien",
+      "other": "Andere"
+    }
   }
 }

--- a/manager/frontend/src/i18n/en.json
+++ b/manager/frontend/src/i18n/en.json
@@ -49,7 +49,8 @@
     "management": "Management",
     "data": "Data",
     "scheduler": "Scheduler",
-    "statistics": "Statistics"
+    "statistics": "Statistics",
+    "assets": "Asset Explorer"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -613,5 +614,55 @@
     "notInstalled": "EasyWebMap Not Installed",
     "notInstalledDesc": "The EasyWebMap mod is not installed. Install it from the Mod Store to enable the live web map feature.",
     "goToModStore": "Go to Mod Store"
+  },
+  "assets": {
+    "title": "Asset Explorer",
+    "subtitle": "Browse and analyze Hytale game assets",
+    "status": "Status",
+    "extracted": "Extracted",
+    "notExtracted": "Not extracted",
+    "sourceFile": "Source File",
+    "sourceNotFound": "Assets.zip not found",
+    "fileCount": "Files",
+    "totalSize": "Total Size",
+    "extractedAt": "Extracted at",
+    "needsUpdate": "Update available",
+    "extract": "Extract Assets",
+    "extracting": "Extracting...",
+    "reExtract": "Re-extract",
+    "clearCache": "Clear Cache",
+    "clearing": "Clearing...",
+    "extractSuccess": "Assets extracted successfully",
+    "clearSuccess": "Asset cache cleared",
+    "browse": "Browse",
+    "search": "Search",
+    "searchPlaceholder": "Search files...",
+    "searchContent": "Also search file content",
+    "noResults": "No results",
+    "noFiles": "No files in this folder",
+    "file": "File",
+    "folder": "Folder",
+    "size": "Size",
+    "modified": "Modified",
+    "path": "Path",
+    "preview": "Preview",
+    "download": "Download",
+    "copyPath": "Copy Path",
+    "backToParent": "Parent Folder",
+    "root": "Root",
+    "viewer": {
+      "json": "JSON Viewer",
+      "image": "Image Preview",
+      "text": "Text Viewer",
+      "hex": "Hex Viewer",
+      "unsupported": "Preview not available"
+    },
+    "filters": {
+      "all": "All Files",
+      "json": "JSON Files",
+      "images": "Images",
+      "text": "Text Files",
+      "other": "Other"
+    }
   }
 }

--- a/manager/frontend/src/i18n/pt_br.json
+++ b/manager/frontend/src/i18n/pt_br.json
@@ -49,7 +49,8 @@
     "management": "Gerenciamento",
     "data": "Dados",
     "scheduler": "Agendador",
-    "statistics": "Estatísticas"
+    "statistics": "Estatísticas",
+    "assets": "Explorador de Assets"
   },
   "dashboard": {
     "title": "Painel",
@@ -613,5 +614,55 @@
     "notInstalled": "EasyWebMap Não Instalado",
     "notInstalledDesc": "O mod EasyWebMap não está instalado. Instale-o na Loja de Mods para ativar o recurso de mapa web ao vivo.",
     "goToModStore": "Ir para Loja de Mods"
+  },
+  "assets": {
+    "title": "Explorador de Assets",
+    "subtitle": "Navegar e analisar assets do jogo Hytale",
+    "status": "Status",
+    "extracted": "Extraído",
+    "notExtracted": "Não extraído",
+    "sourceFile": "Arquivo Fonte",
+    "sourceNotFound": "Assets.zip não encontrado",
+    "fileCount": "Arquivos",
+    "totalSize": "Tamanho Total",
+    "extractedAt": "Extraído em",
+    "needsUpdate": "Atualização disponível",
+    "extract": "Extrair Assets",
+    "extracting": "Extraindo...",
+    "reExtract": "Re-extrair",
+    "clearCache": "Limpar Cache",
+    "clearing": "Limpando...",
+    "extractSuccess": "Assets extraídos com sucesso",
+    "clearSuccess": "Cache de assets limpo",
+    "browse": "Navegar",
+    "search": "Buscar",
+    "searchPlaceholder": "Buscar arquivos...",
+    "searchContent": "Buscar também no conteúdo",
+    "noResults": "Sem resultados",
+    "noFiles": "Sem arquivos nesta pasta",
+    "file": "Arquivo",
+    "folder": "Pasta",
+    "size": "Tamanho",
+    "modified": "Modificado",
+    "path": "Caminho",
+    "preview": "Prévia",
+    "download": "Baixar",
+    "copyPath": "Copiar Caminho",
+    "backToParent": "Pasta Pai",
+    "root": "Raiz",
+    "viewer": {
+      "json": "Visualizador JSON",
+      "image": "Prévia de Imagem",
+      "text": "Visualizador de Texto",
+      "hex": "Visualizador Hex",
+      "unsupported": "Prévia não disponível"
+    },
+    "filters": {
+      "all": "Todos os Arquivos",
+      "json": "Arquivos JSON",
+      "images": "Imagens",
+      "text": "Arquivos de Texto",
+      "other": "Outros"
+    }
   }
 }

--- a/manager/frontend/src/main.ts
+++ b/manager/frontend/src/main.ts
@@ -24,6 +24,7 @@ import ActivityLog from './views/ActivityLog.vue'
 import Scheduler from './views/Scheduler.vue'
 import Statistics from './views/Statistics.vue'
 import WebMap from './views/WebMap.vue'
+import Assets from './views/Assets.vue'
 
 // Import auth store
 import { useAuthStore } from './stores/auth'
@@ -90,6 +91,12 @@ const router = createRouter({
       path: '/mods',
       name: 'mods',
       component: Mods,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/assets',
+      name: 'assets',
+      component: Assets,
       meta: { requiresAuth: true },
     },
     {

--- a/manager/frontend/src/views/Assets.vue
+++ b/manager/frontend/src/views/Assets.vue
@@ -1,0 +1,558 @@
+<script setup lang="ts">
+import { ref, onMounted, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { assetsApi, type AssetStatus, type AssetFileInfo, type FileContent, type SearchResult } from '@/api/assets'
+
+const { t } = useI18n()
+
+// State
+const status = ref<AssetStatus | null>(null)
+const currentPath = ref('')
+const pathHistory = ref<string[]>([])
+const files = ref<AssetFileInfo[]>([])
+const selectedFile = ref<AssetFileInfo | null>(null)
+const fileContent = ref<FileContent | null>(null)
+const searchQuery = ref('')
+const searchContent = ref(false)
+const searchResults = ref<SearchResult[]>([])
+const isSearching = ref(false)
+const showSearch = ref(false)
+
+// Loading states
+const loading = ref(true)
+const loadingFiles = ref(false)
+const loadingContent = ref(false)
+const extracting = ref(false)
+const clearing = ref(false)
+
+// Messages
+const error = ref('')
+const success = ref('')
+
+// Computed
+const breadcrumbs = computed(() => {
+  if (!currentPath.value) return [{ name: t('assets.root'), path: '' }]
+  const parts = currentPath.value.split('/')
+  const crumbs = [{ name: t('assets.root'), path: '' }]
+  let pathSoFar = ''
+  for (const part of parts) {
+    pathSoFar = pathSoFar ? `${pathSoFar}/${part}` : part
+    crumbs.push({ name: part, path: pathSoFar })
+  }
+  return crumbs
+})
+
+const fileTypeIcon = computed(() => (file: AssetFileInfo) => {
+  if (file.type === 'directory') return 'folder'
+  const ext = file.extension?.toLowerCase()
+  if (['.json', '.yml', '.yaml', '.xml'].includes(ext || '')) return 'json'
+  if (['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'].includes(ext || '')) return 'image'
+  if (['.txt', '.md', '.log', '.cfg', '.conf', '.ini', '.lua', '.js', '.ts', '.css', '.html'].includes(ext || '')) return 'text'
+  return 'file'
+})
+
+// Methods
+async function loadStatus() {
+  loading.value = true
+  error.value = ''
+  try {
+    status.value = await assetsApi.getStatus()
+    if (status.value.extracted) {
+      await loadDirectory('')
+    }
+  } catch (e) {
+    error.value = t('errors.connectionFailed')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function extractAssets() {
+  extracting.value = true
+  error.value = ''
+  success.value = ''
+  try {
+    const result = await assetsApi.extract()
+    success.value = t('assets.extractSuccess')
+    await loadStatus()
+    setTimeout(() => success.value = '', 5000)
+  } catch (e) {
+    error.value = 'Extraction failed'
+  } finally {
+    extracting.value = false
+  }
+}
+
+async function clearCache() {
+  clearing.value = true
+  error.value = ''
+  success.value = ''
+  try {
+    await assetsApi.clearCache()
+    success.value = t('assets.clearSuccess')
+    status.value = await assetsApi.getStatus()
+    files.value = []
+    currentPath.value = ''
+    selectedFile.value = null
+    fileContent.value = null
+    setTimeout(() => success.value = '', 5000)
+  } catch (e) {
+    error.value = 'Failed to clear cache'
+  } finally {
+    clearing.value = false
+  }
+}
+
+async function loadDirectory(path: string) {
+  loadingFiles.value = true
+  error.value = ''
+  selectedFile.value = null
+  fileContent.value = null
+  try {
+    const result = await assetsApi.browse(path)
+    files.value = result.items
+    currentPath.value = path
+  } catch (e) {
+    error.value = 'Failed to load directory'
+    files.value = []
+  } finally {
+    loadingFiles.value = false
+  }
+}
+
+async function navigateToFolder(file: AssetFileInfo) {
+  if (file.type !== 'directory') return
+  pathHistory.value.push(currentPath.value)
+  await loadDirectory(file.path)
+}
+
+async function navigateToBreadcrumb(path: string) {
+  pathHistory.value = []
+  await loadDirectory(path)
+}
+
+async function goBack() {
+  const prev = pathHistory.value.pop() || ''
+  await loadDirectory(prev)
+}
+
+async function selectFile(file: AssetFileInfo) {
+  if (file.type === 'directory') {
+    await navigateToFolder(file)
+    return
+  }
+  selectedFile.value = file
+  loadingContent.value = true
+  try {
+    fileContent.value = await assetsApi.readFile(file.path)
+  } catch (e) {
+    fileContent.value = null
+    error.value = 'Failed to load file'
+  } finally {
+    loadingContent.value = false
+  }
+}
+
+async function performSearch() {
+  if (searchQuery.value.length < 2) return
+  isSearching.value = true
+  error.value = ''
+  try {
+    const result = await assetsApi.search(searchQuery.value, {
+      searchContent: searchContent.value,
+      limit: 100,
+    })
+    searchResults.value = result.results
+  } catch (e) {
+    error.value = 'Search failed'
+    searchResults.value = []
+  } finally {
+    isSearching.value = false
+  }
+}
+
+async function selectSearchResult(result: SearchResult) {
+  if (result.type === 'directory') {
+    showSearch.value = false
+    await loadDirectory(result.path)
+  } else {
+    showSearch.value = false
+    // Navigate to parent folder and select file
+    const parentPath = result.path.includes('/') ? result.path.substring(0, result.path.lastIndexOf('/')) : ''
+    await loadDirectory(parentPath)
+    const file = files.value.find(f => f.path === result.path)
+    if (file) {
+      await selectFile(file)
+    }
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleString()
+}
+
+function copyPath() {
+  if (selectedFile.value) {
+    navigator.clipboard.writeText(selectedFile.value.path)
+  }
+}
+
+function downloadFile() {
+  if (selectedFile.value) {
+    window.open(assetsApi.getDownloadUrl(selectedFile.value.path), '_blank')
+  }
+}
+
+// Debounced search
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+watch(searchQuery, () => {
+  if (searchTimeout) clearTimeout(searchTimeout)
+  if (searchQuery.value.length >= 2) {
+    searchTimeout = setTimeout(performSearch, 300)
+  } else {
+    searchResults.value = []
+  }
+})
+
+onMounted(loadStatus)
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Page Title -->
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-white">{{ t('assets.title') }}</h1>
+        <p class="text-gray-400 text-sm">{{ t('assets.subtitle') }}</p>
+      </div>
+      <div class="flex items-center gap-2">
+        <button
+          @click="showSearch = !showSearch"
+          class="px-3 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors flex items-center gap-2"
+          :class="{ 'bg-hytale-orange': showSearch }"
+        >
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          {{ t('assets.search') }}
+        </button>
+        <button
+          @click="loadStatus"
+          class="text-gray-400 hover:text-white transition-colors p-2"
+          :class="{ 'animate-spin': loading }"
+        >
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- Messages -->
+    <div v-if="error" class="p-4 bg-status-error/10 border border-status-error/20 rounded-lg">
+      <p class="text-status-error">{{ error }}</p>
+    </div>
+    <div v-if="success" class="p-4 bg-status-success/10 border border-status-success/20 rounded-lg">
+      <p class="text-status-success">{{ success }}</p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-center py-12 text-gray-400">
+      {{ t('common.loading') }}
+    </div>
+
+    <!-- Search Panel -->
+    <div v-else-if="showSearch" class="card">
+      <div class="card-header">
+        <h3 class="text-lg font-semibold text-white">{{ t('assets.search') }}</h3>
+      </div>
+      <div class="card-body space-y-4">
+        <div class="flex gap-4">
+          <input
+            v-model="searchQuery"
+            type="text"
+            :placeholder="t('assets.searchPlaceholder')"
+            class="flex-1 px-4 py-2 bg-gray-900 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:border-hytale-orange focus:ring-1 focus:ring-hytale-orange"
+          />
+          <label class="flex items-center gap-2 text-gray-400">
+            <input
+              v-model="searchContent"
+              type="checkbox"
+              class="w-4 h-4 rounded bg-gray-700 border-gray-600 text-hytale-orange focus:ring-hytale-orange"
+            />
+            {{ t('assets.searchContent') }}
+          </label>
+        </div>
+
+        <!-- Search Results -->
+        <div v-if="isSearching" class="text-center py-8 text-gray-400">
+          <svg class="w-8 h-8 animate-spin mx-auto mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          {{ t('common.loading') }}
+        </div>
+        <div v-else-if="searchResults.length > 0" class="max-h-96 overflow-y-auto space-y-1">
+          <button
+            v-for="result in searchResults"
+            :key="result.path"
+            @click="selectSearchResult(result)"
+            class="w-full text-left px-4 py-3 bg-gray-800 hover:bg-gray-700 rounded-lg flex items-start gap-3 transition-colors"
+          >
+            <svg v-if="result.type === 'directory'" class="w-5 h-5 text-yellow-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+            </svg>
+            <svg v-else class="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            <div class="flex-1 min-w-0">
+              <p class="text-white font-medium truncate">{{ result.name }}</p>
+              <p class="text-gray-500 text-sm truncate">{{ result.path }}</p>
+              <p v-if="result.contentPreview" class="text-gray-400 text-xs mt-1 truncate">{{ result.contentPreview }}</p>
+            </div>
+            <span v-if="result.matchType === 'content'" class="text-xs text-hytale-orange bg-hytale-orange/20 px-2 py-0.5 rounded">Content</span>
+          </button>
+        </div>
+        <div v-else-if="searchQuery.length >= 2" class="text-center py-8 text-gray-400">
+          {{ t('assets.noResults') }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Status Card (when not extracted) -->
+    <div v-else-if="status && !status.extracted" class="card">
+      <div class="card-header">
+        <h3 class="text-lg font-semibold text-white">{{ t('assets.status') }}</h3>
+      </div>
+      <div class="card-body">
+        <div class="text-center py-8">
+          <svg class="w-16 h-16 mx-auto text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z" />
+          </svg>
+          <p class="text-gray-400 mb-2">{{ t('assets.notExtracted') }}</p>
+          <p v-if="status.sourceExists" class="text-gray-500 text-sm mb-4">
+            {{ t('assets.sourceFile') }}: {{ status.sourceFile?.split('/').pop() }}
+          </p>
+          <p v-else class="text-status-error text-sm mb-4">{{ t('assets.sourceNotFound') }}</p>
+          <button
+            v-if="status.sourceExists"
+            @click="extractAssets"
+            :disabled="extracting"
+            class="px-6 py-3 bg-hytale-orange hover:bg-hytale-orange/80 disabled:bg-gray-600 text-white font-medium rounded-lg transition-colors"
+          >
+            {{ extracting ? t('assets.extracting') : t('assets.extract') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Main Browser -->
+    <template v-else-if="status && status.extracted">
+      <!-- Status Bar -->
+      <div class="card">
+        <div class="card-body py-3">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-6 text-sm">
+              <span class="text-gray-400">
+                <span class="text-white font-medium">{{ status.fileCount.toLocaleString() }}</span> {{ t('assets.fileCount') }}
+              </span>
+              <span class="text-gray-400">
+                <span class="text-white font-medium">{{ formatSize(status.totalSize) }}</span> {{ t('assets.totalSize') }}
+              </span>
+              <span v-if="status.extractedAt" class="text-gray-400">
+                {{ t('assets.extractedAt') }}: <span class="text-white">{{ formatDate(status.extractedAt) }}</span>
+              </span>
+              <span v-if="status.needsUpdate" class="text-status-warning flex items-center gap-1">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                {{ t('assets.needsUpdate') }}
+              </span>
+            </div>
+            <div class="flex items-center gap-2">
+              <button
+                @click="extractAssets"
+                :disabled="extracting"
+                class="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 text-white text-sm rounded-lg transition-colors"
+              >
+                {{ extracting ? t('assets.extracting') : t('assets.reExtract') }}
+              </button>
+              <button
+                @click="clearCache"
+                :disabled="clearing"
+                class="px-3 py-1.5 bg-gray-700 hover:bg-status-error/20 hover:text-status-error disabled:bg-gray-800 text-gray-400 text-sm rounded-lg transition-colors"
+              >
+                {{ clearing ? t('assets.clearing') : t('assets.clearCache') }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Browser Grid -->
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- File List -->
+        <div class="card lg:col-span-1">
+          <div class="card-header">
+            <h3 class="text-lg font-semibold text-white">{{ t('assets.browse') }}</h3>
+          </div>
+          <div class="card-body p-0">
+            <!-- Breadcrumbs -->
+            <div class="px-4 py-2 border-b border-gray-700 flex items-center gap-1 text-sm overflow-x-auto">
+              <template v-for="(crumb, i) in breadcrumbs" :key="crumb.path">
+                <button
+                  @click="navigateToBreadcrumb(crumb.path)"
+                  class="text-gray-400 hover:text-white transition-colors whitespace-nowrap"
+                  :class="{ 'text-hytale-orange font-medium': i === breadcrumbs.length - 1 }"
+                >
+                  {{ crumb.name }}
+                </button>
+                <span v-if="i < breadcrumbs.length - 1" class="text-gray-600">/</span>
+              </template>
+            </div>
+
+            <!-- Back button -->
+            <button
+              v-if="currentPath"
+              @click="goBack"
+              class="w-full px-4 py-2 text-left hover:bg-gray-700/50 flex items-center gap-2 border-b border-gray-700 text-gray-400"
+            >
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
+              </svg>
+              {{ t('assets.backToParent') }}
+            </button>
+
+            <!-- File list -->
+            <div class="overflow-y-auto" style="max-height: calc(100vh - 400px);">
+              <div v-if="loadingFiles" class="text-center py-8 text-gray-400">
+                {{ t('common.loading') }}
+              </div>
+              <div v-else-if="files.length === 0" class="text-center py-8 text-gray-400">
+                {{ t('assets.noFiles') }}
+              </div>
+              <button
+                v-else
+                v-for="file in files"
+                :key="file.path"
+                @click="selectFile(file)"
+                class="w-full px-4 py-2 text-left hover:bg-gray-700/50 flex items-center gap-3 border-b border-gray-700/50 transition-colors"
+                :class="{ 'bg-hytale-orange/20 border-l-2 border-l-hytale-orange': selectedFile?.path === file.path }"
+              >
+                <!-- Icon -->
+                <svg v-if="file.type === 'directory'" class="w-5 h-5 text-yellow-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                </svg>
+                <svg v-else-if="fileTypeIcon(file) === 'json'" class="w-5 h-5 text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <svg v-else-if="fileTypeIcon(file) === 'image'" class="w-5 h-5 text-purple-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <svg v-else-if="fileTypeIcon(file) === 'text'" class="w-5 h-5 text-blue-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <svg v-else class="w-5 h-5 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                </svg>
+                <!-- Name and info -->
+                <div class="flex-1 min-w-0">
+                  <p class="text-white truncate">{{ file.name }}</p>
+                  <p v-if="file.type === 'file'" class="text-gray-500 text-xs">{{ formatSize(file.size) }}</p>
+                </div>
+                <!-- Arrow for folders -->
+                <svg v-if="file.type === 'directory'" class="w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- File Viewer -->
+        <div class="lg:col-span-2">
+          <div v-if="loadingContent" class="card">
+            <div class="card-body text-center py-12">
+              <svg class="w-8 h-8 animate-spin mx-auto text-hytale-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </div>
+          </div>
+
+          <div v-else-if="selectedFile && fileContent" class="card">
+            <div class="card-header flex items-center justify-between">
+              <div>
+                <h3 class="text-lg font-semibold text-white">{{ selectedFile.name }}</h3>
+                <p class="text-sm text-gray-400">{{ selectedFile.path }}</p>
+              </div>
+              <div class="flex items-center gap-2">
+                <button
+                  @click="copyPath"
+                  class="p-2 text-gray-400 hover:text-white transition-colors"
+                  :title="t('assets.copyPath')"
+                >
+                  <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  </svg>
+                </button>
+                <button
+                  @click="downloadFile"
+                  class="p-2 text-gray-400 hover:text-white transition-colors"
+                  :title="t('assets.download')"
+                >
+                  <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div class="card-body">
+              <!-- Image viewer -->
+              <div v-if="fileContent.mimeType?.startsWith('image/')" class="text-center">
+                <img
+                  :src="`data:${fileContent.mimeType};base64,${fileContent.content}`"
+                  :alt="selectedFile.name"
+                  class="max-w-full max-h-[500px] mx-auto rounded-lg border border-gray-700"
+                />
+                <p class="text-gray-500 text-sm mt-2">{{ formatSize(fileContent.size) }}</p>
+              </div>
+
+              <!-- JSON viewer -->
+              <div v-else-if="fileContent.mimeType === 'application/json'" class="relative">
+                <pre class="bg-gray-900 p-4 rounded-lg text-sm text-gray-300 overflow-auto max-h-[500px] font-mono">{{ typeof fileContent.content === 'string' ? JSON.stringify(JSON.parse(fileContent.content), null, 2) : fileContent.content }}</pre>
+              </div>
+
+              <!-- Text viewer -->
+              <div v-else-if="!fileContent.isBinary" class="relative">
+                <pre class="bg-gray-900 p-4 rounded-lg text-sm text-gray-300 overflow-auto max-h-[500px] font-mono whitespace-pre-wrap">{{ fileContent.content }}</pre>
+              </div>
+
+              <!-- Hex viewer -->
+              <div v-else class="relative">
+                <p class="text-gray-400 mb-2">{{ t('assets.viewer.hex') }} (first 1KB)</p>
+                <pre class="bg-gray-900 p-4 rounded-lg text-xs text-gray-400 overflow-auto max-h-[400px] font-mono">{{ fileContent.content }}</pre>
+                <p class="text-gray-500 text-sm mt-2">{{ formatSize(fileContent.size) }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- No file selected -->
+          <div v-else class="card">
+            <div class="card-body text-center py-12">
+              <svg class="w-16 h-16 mx-auto text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <p class="text-gray-400">{{ t('assets.preview') }}</p>
+              <p class="text-gray-500 text-sm mt-1">Select a file from the list to view its contents</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>


### PR DESCRIPTION
- Add backend asset service for extracting, browsing, and reading Assets.zip
- Add API routes for asset status, extraction, browsing, searching, and file viewing
- Add new assetsPath config option (separate from backups to avoid backup bloat)
- Add Asset Explorer view with:
  - Status panel showing extraction state and update detection
  - Directory browser with breadcrumb navigation
  - Search functionality (filename and content search)
  - File viewers for JSON, images, text, and hex preview
  - Download and copy path actions
- Add navigation entry in sidebar (Management section)
- Add translations for German, English, and Portuguese