### PR TITLE
fix: use MANAGER_DATA_PATH for persistent manager data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,8 @@ services:
       - BACKUPS_PATH=/opt/hytale/backups
       - DATA_PATH=/opt/hytale/data
       - ASSETS_PATH=/opt/hytale/assets
+      # Manager persistent data path (for users, roles, config, logs)
+      - MANAGER_DATA_PATH=/app/data
 
       # Settings
       - TZ=${TZ:-Europe/Berlin}

--- a/manager/backend/src/config.ts
+++ b/manager/backend/src/config.ts
@@ -9,8 +9,8 @@ dotenv.config();
 // Config.json Integration
 // ============================================================
 
-// Path to config.json (same as in configService.ts)
-const DATA_PATH = process.env.DATA_PATH || '/opt/hytale/data';
+// Path to config.json (same as in configService.ts, persistent volume)
+const DATA_PATH = process.env.MANAGER_DATA_PATH || '/app/data';
 const CONFIG_FILE_PATH = path.join(DATA_PATH, 'config.json');
 
 // Interface for config.json (simplified for this module)

--- a/manager/backend/src/services/activityLog.ts
+++ b/manager/backend/src/services/activityLog.ts
@@ -19,7 +19,7 @@ const activityLog: ActivityLogEntry[] = [];
 const MAX_LOG_ENTRIES = 500;
 
 // Path to persistent log file
-const DATA_DIR = process.env.DATA_PATH || '/app/data';
+const DATA_DIR = process.env.MANAGER_DATA_PATH || '/app/data';
 const LOG_FILE = path.join(DATA_DIR, 'activity-log.json');
 
 // Generate unique ID

--- a/manager/backend/src/services/chatLog.ts
+++ b/manager/backend/src/services/chatLog.ts
@@ -38,7 +38,7 @@ const playerDeathPositions: Map<string, DeathPosition[]> = new Map();
 const MAX_DEATH_POSITIONS = 10; // Keep last 10 death positions per player
 
 // Data directory paths
-const DATA_DIR = process.env.DATA_PATH || '/app/data';
+const DATA_DIR = process.env.MANAGER_DATA_PATH || '/app/data';
 const CHAT_DIR = path.join(DATA_DIR, 'chat');
 const GLOBAL_CHAT_DIR = path.join(CHAT_DIR, 'global');
 const PLAYER_CHAT_DIR = path.join(CHAT_DIR, 'players');

--- a/manager/backend/src/services/configService.ts
+++ b/manager/backend/src/services/configService.ts
@@ -77,8 +77,8 @@ export interface PanelConfig {
 // Constants
 // ============================================================
 
-// Config file location inside container
-const DATA_PATH = process.env.DATA_PATH || '/opt/hytale/data';
+// Config file location inside container (persistent volume)
+const DATA_PATH = process.env.MANAGER_DATA_PATH || '/app/data';
 const CONFIG_FILENAME = 'config.json';
 const CONFIG_TEMP_SUFFIX = '.tmp';
 

--- a/manager/backend/src/services/roles.ts
+++ b/manager/backend/src/services/roles.ts
@@ -12,7 +12,7 @@ import { getUser, getAllUsers, invalidateUserTokens } from './users.js';
 import { isDemoMode } from './demoData.js';
 
 // Path to roles file in the persistent data volume
-const DATA_DIR = process.env.DATA_PATH || '/app/data';
+const DATA_DIR = process.env.MANAGER_DATA_PATH || '/app/data';
 const ROLES_FILE = path.join(DATA_DIR, 'roles.json');
 
 // Ensure data directory exists

--- a/manager/backend/src/services/users.ts
+++ b/manager/backend/src/services/users.ts
@@ -26,7 +26,7 @@ interface UsersData {
 }
 
 // Path to users file in the persistent data volume
-const DATA_DIR = process.env.DATA_PATH || '/app/data';
+const DATA_DIR = process.env.MANAGER_DATA_PATH || '/app/data';
 const USERS_FILE = path.join(DATA_DIR, 'users.json');
 
 // Ensure data directory exists


### PR DESCRIPTION
Previously, manager data (users, roles, config, activity logs, chat logs) was stored in DATA_PATH which was set to /opt/hytale/data - a bind mount for game world data. This caused all manager data to be lost after stack restarts because it wasn't in the persistent named volume.

Now using MANAGER_DATA_PATH=/app/data which points to the manager-data named volume, ensuring users, roles, and config persist across restarts.

https://claude.ai/code/session_019cypgQckPDUpGn4jhSzsZb