### PR TITLE
Ensure updater directory exists with correct permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN groupadd -g 9999 hytale \
     && useradd -u 9999 -g hytale -m -s /bin/bash hytale \
     && mkdir -p /opt/hytale/server \
+                /opt/hytale/server/updater \
                 /opt/hytale/data \
                 /opt/hytale/backups \
                 /opt/hytale/plugins \

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -31,6 +31,9 @@ echo ""
 echo "[INFO] Setting up directories..."
 # Set umask 002 so all new files are group-writable (for manager container access)
 umask 002
+# Ensure updater directory exists with correct permissions.
+# It is bind-mounted from the host and may be created as root by Docker on first run.
+mkdir -p /opt/hytale/server/updater
 chown -R hytale:hytale /opt/hytale
 # Make existing files group-writable for manager container
 chmod -R g+rw /opt/hytale 2>/dev/null || true


### PR DESCRIPTION
## Summary
This PR ensures the `/opt/hytale/server/updater` directory is properly created and has correct permissions in both the Docker image build and container startup phases.

## Key Changes
- **Dockerfile**: Added explicit creation of `/opt/hytale/server/updater` directory during image build with proper ownership
- **entrypoint.sh**: Added runtime directory creation and permission setup for the updater directory to handle cases where it may be created as root by Docker when bind-mounted from the host

## Implementation Details
The updater directory is bind-mounted from the host and may be created as root by Docker on first run. By creating it explicitly in both the Dockerfile (for the base image) and entrypoint.sh (for runtime), we ensure:
- The directory exists with the correct `hytale:hytale` ownership
- Proper group-writable permissions are applied for manager container access
- The setup is resilient to different Docker mount scenarios

https://claude.ai/code/session_017REctbaeuE7ps3YBc5Fsfd